### PR TITLE
ci: bump actions/checkout v3/v4 -> v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
     name: Check JSON Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -113,7 +113,7 @@ jobs:
     name: Check Version Consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Check version strings are in sync
         run: |
@@ -244,7 +244,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -259,7 +259,7 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       
       - name: Install Rust 1.85
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/claude-schema-drift.yml
+++ b/.github/workflows/claude-schema-drift.yml
@@ -28,7 +28,7 @@ jobs:
     name: diff installed CLI schema vs snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/codex-schema-drift.yml
+++ b/.github/workflows/codex-schema-drift.yml
@@ -21,7 +21,7 @@ jobs:
     name: diff snapshotted vs upstream
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -30,7 +30,7 @@ jobs:
             args: "-p claude-codes --features auth"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -63,7 +63,7 @@ jobs:
             args: "-p codex-codes"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -96,7 +96,7 @@ jobs:
             args: "-p opencode-codes"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -127,7 +127,7 @@ jobs:
             args: "-p muse-codes"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -160,7 +160,7 @@ jobs:
             args: "-p muse-codes --no-default-features --features types"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Rust with WASM target
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/muse-schema-drift.yml
+++ b/.github/workflows/muse-schema-drift.yml
@@ -19,7 +19,7 @@ jobs:
     name: diff installed CLI stream vs fingerprint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/opencode-schema-drift.yml
+++ b/.github/workflows/opencode-schema-drift.yml
@@ -30,7 +30,7 @@ jobs:
     name: diff live opencode /doc vs snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
In its own PR as requested — bumps every `actions/checkout` pin to the verified newest major.

- Verified live via `curl https://api.github.com/repos/actions/checkout/releases/latest` in one uninterrupted pass: **latest tag `v7.0.1`**, `published_at: 2026-07-20T15:10:05Z`, `html_url: https://github.com/actions/checkout/releases/tag/v7.0.1`. Top-5 listing also confirms: `v7.0.1`, `v6.1.0`, `v5.1.0`, `v4.4.0`, `v3.7.0`.
- Repo was mixed: `ci.yml` still on `actions/checkout@v3` (5 jobs), `feature-matrix.yml` + 4 drift workflows on `v4`. All 6 files now use `actions/checkout@v7` (14 pins total):
  - `.github/workflows/ci.yml` (5)
  - `.github/workflows/feature-matrix.yml` (5)
  - `.github/workflows/claude-schema-drift.yml`, `codex-schema-drift.yml`, `muse-schema-drift.yml`, `opencode-schema-drift.yml` (1 each)
- v7 requires Node 24 (v6 already did) and backports the safer `pull_request_target`/`workflow_run` checkout hardening from the 2026-06-18 blog post — no workflow logic changed.

Test: local `grep -r "actions/checkout" .github/` shows only `v7` pins; `git diff` as above.