### PR TITLE
Pin conversation_reset identity rotation with a live test

### DIFF
--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -253,10 +253,31 @@ pub struct PromptSuggestionMessage {
     pub session_id: String,
 }
 
+/// Emitted when the conversation is reset mid-stream (e.g. `/clear` sent as
+/// user input). **Identity semantics, measured live against CLI 2.1.232 —
+/// two traps here:**
+///
+/// 1. **The session id rotates.** After this frame the same process re-inits
+///    and every subsequent frame carries a NEW `session_id`; both the old
+///    and new ids get real transcript files on disk. A consumer keying a
+///    live stream's transcript by its first-seen session id will
+///    mis-attribute everything after a reset — treat this frame as a
+///    session-identity boundary and adopt the next `system` init's id.
+/// 2. **`new_conversation_id` is not the successor session id.** In live
+///    measurement it matched nothing: not the post-reset `session_id`, no
+///    transcript file, never referenced by any later frame. Do not key on
+///    it.
+///
+/// Pinned by `conversation_reset_rotates_the_session_id` in the live
+/// integration tests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationResetMessage {
+    /// A fresh id announced for the new conversation. **Not** observed to
+    /// match the post-reset `session_id` or anything else on the wire or
+    /// disk — see the type-level docs before using.
     pub new_conversation_id: String,
     pub uuid: String,
+    /// The OLD session id — the identity being retired by this reset.
     pub session_id: String,
 }
 

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -2560,3 +2560,83 @@ fn test_rejected_flow_retries_with_new_url_live() {
         other => panic!("round 2 should reach a live input field, got {other:?}"),
     }
 }
+
+/// `/clear` mid-stream rotates the SESSION id: a `conversation_reset` frame
+/// arrives carrying the OLD session id plus a `new_conversation_id` that
+/// matches NOTHING (not the successor session, no disk file — a phantom id
+/// consumers must not key on), and the stream then re-inits under a fresh
+/// session id that carries subsequent turns. Pins the identity boundary a
+/// transcript-keeper has to handle.
+#[tokio::test]
+async fn conversation_reset_rotates_the_session_id() {
+    let run = async {
+        let mut client = AsyncClient::with_defaults().await.expect("spawn claude");
+        let first_turn = client
+            .query("Reply with exactly: one")
+            .await
+            .expect("first turn");
+        // The wire's own identity, not the client-minted uuid: the id the
+        // first turn's frames actually carried.
+        let original = first_turn
+            .iter()
+            .find_map(|o| match o {
+                ClaudeOutput::Result(r) => Some(r.session_id.clone()),
+                _ => None,
+            })
+            .expect("first turn carries a session id");
+
+        client
+            .send(&ClaudeInput::user_message_without_session("/clear"))
+            .await
+            .expect("send /clear");
+
+        let mut reset: Option<claude_codes::io::ConversationResetMessage> = None;
+        let mut post_reset_session: Option<String> = None;
+        for _ in 0..50 {
+            match client.receive().await.expect("receive") {
+                ClaudeOutput::ConversationReset(msg) => {
+                    assert_eq!(
+                        msg.session_id, original,
+                        "the reset frame must name the session it retires"
+                    );
+                    reset = Some(msg);
+                }
+                ClaudeOutput::System(sys) if sys.is_init() && reset.is_some() => {
+                    post_reset_session = sys
+                        .data
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let reset = reset.expect("conversation_reset frame must arrive after /clear");
+        let rotated = post_reset_session.expect("a fresh system init must follow the reset");
+        assert_ne!(
+            rotated, original,
+            "the session id must ROTATE after a reset"
+        );
+        assert_ne!(
+            rotated, reset.new_conversation_id,
+            "new_conversation_id is a phantom — it must not be assumed to be \
+             the successor session id (if this ever fails, the CLI unified \
+             the identities and the ConversationResetMessage docs must change)"
+        );
+
+        // The rotated id is live: a turn completes under it.
+        let outputs = client
+            .query("Reply with exactly: two")
+            .await
+            .expect("post-reset turn");
+        assert!(
+            outputs.iter().any(|o| matches!(o, ClaudeOutput::Result(_))),
+            "the post-reset session must carry a full turn"
+        );
+        client.shutdown().await.expect("shutdown");
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(180), run)
+        .await
+        .expect("reset round trip within 180s");
+}


### PR DESCRIPTION
Fixes #315 — with a finding: the frame was **already typed** (since #216); the report came from agent-portal's raw-frame fallback because the *portal's* wrapper doesn't map the variant (handed off to the portal session separately).

What the SDK was actually missing is the identity semantics, now **measured live** and pinned:

1. **`/clear` rotates the session id.** The same process re-inits under a fresh `session_id`; both old and new ids get real transcript files on disk. Keying a live transcript by first-seen session id mis-attributes everything post-reset.
2. **`new_conversation_id` is a phantom.** It matches nothing — not the successor session id, no disk file, never referenced by any later frame. Do not key on it.

`ConversationResetMessage` docs now carry both traps, and a new annotated live test (`conversation_reset_rotates_the_session_id`) drives `/clear` through the stream: reset frame names the retired id → successor init carries a rotated id ≠ `new_conversation_id` → a full turn completes under the rotated id. If the CLI ever unifies the identities, the test fails and the docs get updated rather than silently rotting.