### PR TITLE
codex-codes 0.147.0: resnapshot vs openai/codex@main, project surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.223"
+version = "2.1.232"
 dependencies = [
  "anyhow",
  "base64",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.4"
+version = "0.147.0"
 dependencies = [
  "env_logger",
  "jsonschema",
@@ -1296,7 +1296,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opencode-codes"
-version = "1.18.14"
+version = "1.18.18"
 dependencies = [
  "futures-core",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.232`, tested against Claude CLI `2.1.232`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.147.0`, tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.18`, tested against opencode `1.18.18`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 - **`antigravity-codes`** version tracks the `google-antigravity` wheel whose bundled harness it was generated from. Currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10`.

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.0] - 2026-08-19
+
+### Added
+
+- **Project surface** (upstream 0.147): `Project`/`ProjectRoot`/
+  `ProjectChangeType` types, `Thread.project_id`, and typed notifications
+  `project/changed` and `thread/project/updated`.
+- **Queue + revert notifications**: `thread/queue/changed` (with
+  `QueuedSubmission`) and `thread/reverted`, plus
+  `autoApprovalReview/strictReviewRequired` — all five wired through
+  `Notification` with method constants and `into_envelope` round trips.
+- **Per-thread usage types** (stranded on main since the previous
+  resnapshot at 0.146.4 — an already-published version, so this release
+  finally ships them): `ThreadUsage`, `ThreadUsageBreakdownGroup`,
+  `GetAccountTokenUsageParams`, `ImageGenerationFailure`,
+  `McpServerOauthClientRegistration`.
+- Field additions: `HookMetadata` mcpTool-hook fields (`server`, `tool`,
+  `async`) with `HookHandlerType::McpTool`; `ConfigRequirements`
+  `chatgptBaseUrl`/`cliAuthCredentialsStore`;
+  `McpResourceReadParams`/`Response` `connectorId`/`originCallId`;
+  `ModelUpgradeInfo.retirementAt`; `ThreadItem::AgentMessage.delivery`;
+  `CodexErrorInfo::MisalignmentPolicyViolation`; `PlanType`
+  `edu_plus`/`edu_pro`.
+
+### Changed
+
+- Schema snapshots re-pinned byte-identical to `openai/codex@main`
+  (fixes the nightly drift report); crate version tracks the installed
+  CLI 0.147.0, live-verified via wirecheck.
+
 ## [0.146.4] - 2026-08-05
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.146.4"
+version = "0.147.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.146.0
+**Tested against:** Codex CLI 0.147.0
 
 ## Installation
 

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -41,16 +41,18 @@ use crate::protocol::{
     McpServerOauthLoginCompletedNotification, McpServerStatusUpdatedNotification,
     McpToolCallProgressNotification, ModelReroutedNotification,
     ModelSafetyBufferingUpdatedNotification, ModelVerificationNotification, PlanDeltaNotification,
-    ProcessExitedNotification, ProcessOutputDeltaNotification,
+    ProcessExitedNotification, ProcessOutputDeltaNotification, ProjectChangedNotification,
     ReasoningSummaryPartAddedNotification, ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification, RemoteControlStatusChangedNotification,
-    ServerRequestResolvedNotification, SkillsChangedNotification, TerminalInteractionNotification,
-    ThreadArchivedNotification, ThreadClosedNotification, ThreadDeletedNotification,
-    ThreadGoalClearedNotification, ThreadGoalUpdatedNotification, ThreadNameUpdatedNotification,
-    ThreadRealtimeClosedNotification, ThreadRealtimeErrorNotification,
-    ThreadRealtimeItemAddedNotification, ThreadRealtimeOutputAudioDeltaNotification,
-    ThreadRealtimeSdpNotification, ThreadRealtimeStartedNotification,
-    ThreadRealtimeTranscriptDeltaNotification, ThreadRealtimeTranscriptDoneNotification,
+    ServerRequestResolvedNotification, SkillsChangedNotification, StrictReviewRequiredNotification,
+    TerminalInteractionNotification, ThreadArchivedNotification, ThreadClosedNotification,
+    ThreadDeletedNotification, ThreadGoalClearedNotification, ThreadGoalUpdatedNotification,
+    ThreadNameUpdatedNotification, ThreadProjectUpdatedNotification,
+    ThreadQueueChangedNotification, ThreadRealtimeClosedNotification,
+    ThreadRealtimeErrorNotification, ThreadRealtimeItemAddedNotification,
+    ThreadRealtimeOutputAudioDeltaNotification, ThreadRealtimeSdpNotification,
+    ThreadRealtimeStartedNotification, ThreadRealtimeTranscriptDeltaNotification,
+    ThreadRealtimeTranscriptDoneNotification, ThreadRevertedNotification,
     ThreadSettingsUpdatedNotification, ThreadStartedNotification, ThreadStatusChangedNotification,
     ThreadTokenUsageUpdatedNotification, ThreadUnarchivedNotification, TurnCompletedNotification,
     TurnDiffUpdatedNotification, TurnModerationMetadataNotification, TurnPlanUpdatedNotification,
@@ -207,6 +209,16 @@ pub enum Notification {
     ThreadEnvironmentConnected(EnvironmentConnectionNotification),
     /// `thread/environment/disconnected`
     ThreadEnvironmentDisconnected(EnvironmentConnectionNotification),
+    /// `autoApprovalReview/strictReviewRequired` (0.147)
+    StrictReviewRequired(StrictReviewRequiredNotification),
+    /// `project/changed` (0.147)
+    ProjectChanged(ProjectChangedNotification),
+    /// `thread/project/updated` (0.147)
+    ThreadProjectUpdated(ThreadProjectUpdatedNotification),
+    /// `thread/queue/changed` (0.147)
+    ThreadQueueChanged(ThreadQueueChangedNotification),
+    /// `thread/reverted` (0.147)
+    ThreadReverted(ThreadRevertedNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -221,6 +233,11 @@ impl Notification {
     pub fn method(&self) -> &str {
         match self {
             Self::ThreadStarted(_) => methods::THREAD_STARTED,
+            Self::StrictReviewRequired(_) => methods::STRICT_REVIEW_REQUIRED,
+            Self::ProjectChanged(_) => methods::PROJECT_CHANGED,
+            Self::ThreadProjectUpdated(_) => methods::THREAD_PROJECT_UPDATED,
+            Self::ThreadQueueChanged(_) => methods::THREAD_QUEUE_CHANGED,
+            Self::ThreadReverted(_) => methods::THREAD_REVERTED,
             Self::ThreadStatusChanged(_) => methods::THREAD_STATUS_CHANGED,
             Self::ThreadTokenUsageUpdated(_) => methods::THREAD_TOKEN_USAGE_UPDATED,
             Self::TurnStarted(_) => methods::TURN_STARTED,
@@ -375,6 +392,21 @@ impl Notification {
         match method {
             methods::THREAD_STARTED => {
                 serde_json::from_value(params_value).map(Self::ThreadStarted)
+            }
+            methods::STRICT_REVIEW_REQUIRED => {
+                serde_json::from_value(params_value).map(Self::StrictReviewRequired)
+            }
+            methods::PROJECT_CHANGED => {
+                serde_json::from_value(params_value).map(Self::ProjectChanged)
+            }
+            methods::THREAD_PROJECT_UPDATED => {
+                serde_json::from_value(params_value).map(Self::ThreadProjectUpdated)
+            }
+            methods::THREAD_QUEUE_CHANGED => {
+                serde_json::from_value(params_value).map(Self::ThreadQueueChanged)
+            }
+            methods::THREAD_REVERTED => {
+                serde_json::from_value(params_value).map(Self::ThreadReverted)
             }
             methods::THREAD_STATUS_CHANGED => {
                 serde_json::from_value(params_value).map(Self::ThreadStatusChanged)
@@ -584,6 +616,11 @@ impl Notification {
         }
         match &self {
             Self::ThreadStarted(v) => pack(methods::THREAD_STARTED, v),
+            Self::StrictReviewRequired(v) => pack(methods::STRICT_REVIEW_REQUIRED, v),
+            Self::ProjectChanged(v) => pack(methods::PROJECT_CHANGED, v),
+            Self::ThreadProjectUpdated(v) => pack(methods::THREAD_PROJECT_UPDATED, v),
+            Self::ThreadQueueChanged(v) => pack(methods::THREAD_QUEUE_CHANGED, v),
+            Self::ThreadReverted(v) => pack(methods::THREAD_REVERTED, v),
             Self::ThreadStatusChanged(v) => pack(methods::THREAD_STATUS_CHANGED, v),
             Self::ThreadTokenUsageUpdated(v) => pack(methods::THREAD_TOKEN_USAGE_UPDATED, v),
             Self::TurnStarted(v) => pack(methods::TURN_STARTED, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -128,6 +128,11 @@ pub mod methods {
 
     // Server → client notifications
     pub const THREAD_STARTED: &str = "thread/started";
+    pub const STRICT_REVIEW_REQUIRED: &str = "autoApprovalReview/strictReviewRequired";
+    pub const PROJECT_CHANGED: &str = "project/changed";
+    pub const THREAD_PROJECT_UPDATED: &str = "thread/project/updated";
+    pub const THREAD_QUEUE_CHANGED: &str = "thread/queue/changed";
+    pub const THREAD_REVERTED: &str = "thread/reverted";
     pub const THREAD_STATUS_CHANGED: &str = "thread/status/changed";
     pub const THREAD_TOKEN_USAGE_UPDATED: &str = "thread/tokenUsage/updated";
     pub const TURN_STARTED: &str = "turn/started";

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -730,6 +730,8 @@ pub enum CodexErrorInfo {
     ServerOverloaded,
     #[serde(rename = "cyberPolicy")]
     CyberPolicy,
+    #[serde(rename = "misalignmentPolicyViolation")]
+    MisalignmentPolicyViolation,
     #[serde(rename = "internalServerError")]
     InternalServerError,
     #[serde(rename = "unauthorized")]
@@ -1332,6 +1334,18 @@ pub struct ConfigReadResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigRequirements {
+    #[serde(
+        rename = "chatgptBaseUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chatgpt_base_url: Option<String>,
+    #[serde(
+        rename = "cliAuthCredentialsStore",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cli_auth_credentials_store: Option<CliAuthCredentialsStoreMode>,
     #[serde(
         rename = "allowAppshots",
         default,
@@ -2863,6 +2877,8 @@ pub enum HookExecutionMode {
 pub enum HookHandlerType {
     #[serde(rename = "command")]
     Command,
+    #[serde(rename = "mcpTool")]
+    McpTool,
     #[serde(rename = "prompt")]
     Prompt,
     #[serde(rename = "agent")]
@@ -2878,10 +2894,18 @@ pub struct HookMetadata {
         skip_serializing_if = "Option::is_none"
     )]
     pub additional_context_limit: Option<i64>,
+    #[serde(rename = "async", default, skip_serializing_if = "Option::is_none")]
+    pub is_async: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(rename = "currentHash", default)]
     pub current_hash: String,
+    /// MCP server name (`handlerType: "mcpTool"` hooks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+    /// MCP tool name (`handlerType: "mcpTool"` hooks).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
     #[serde(rename = "displayOrder", default)]
     pub display_order: i64,
     #[serde(default)]
@@ -3758,6 +3782,19 @@ pub struct McpElicitationUntitledSingleSelectEnumSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct McpResourceReadParams {
+    #[serde(
+        rename = "connectorId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub connector_id: Option<String>,
+    /// Originating MCP tool call used to select the resource's app.
+    #[serde(
+        rename = "originCallId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub origin_call_id: Option<String>,
     #[serde(default)]
     pub server: String,
     #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
@@ -3771,6 +3808,14 @@ pub struct McpResourceReadParams {
 pub struct McpResourceReadResponse {
     #[serde(default)]
     pub contents: Vec<ResourceContent>,
+    /// Originating call when the server applied app-specific resource
+    /// scoping.
+    #[serde(
+        rename = "originCallId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub origin_call_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -4335,6 +4380,14 @@ pub struct ModelUpgradeInfo {
     pub migration_markdown: Option<String>,
     #[serde(default)]
     pub model: String,
+    /// Informational Unix timestamp for this upgrade's scheduled
+    /// retirement, if known.
+    #[serde(
+        rename = "retirementAt",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub retirement_at: Option<i64>,
     #[serde(rename = "modelLink", default, skip_serializing_if = "Option::is_none")]
     pub model_link: Option<String>,
     #[serde(
@@ -4629,6 +4682,10 @@ pub enum PlanType {
     Pro,
     #[serde(rename = "prolite")]
     Prolite,
+    #[serde(rename = "edu_plus")]
+    Edu_plus,
+    #[serde(rename = "edu_pro")]
+    Edu_pro,
     #[serde(rename = "team")]
     Team,
     #[serde(rename = "self_serve_business_prolite")]
@@ -5765,6 +5822,115 @@ pub enum ReviewTarget {
     },
 }
 
+/// Delivery mode for an agent message item (0.147: currently only `async`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum AgentMessageDelivery {
+    #[serde(rename = "async")]
+    Async,
+}
+
+/// Where the CLI stores auth credentials.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CliAuthCredentialsStoreMode {
+    #[serde(rename = "file")]
+    File,
+    #[serde(rename = "keyring")]
+    Keyring,
+    #[serde(rename = "auto")]
+    Auto,
+    #[serde(rename = "ephemeral")]
+    Ephemeral,
+}
+
+/// A project grouping threads, owned by app-server.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Project {
+    #[serde(rename = "createdAt", default)]
+    pub created_at: i64,
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub metadata: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub position: i64,
+    #[serde(default)]
+    pub roots: Vec<ProjectRoot>,
+    #[serde(rename = "updatedAt", default)]
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ProjectChangeType {
+    #[serde(rename = "created")]
+    Created,
+    #[serde(rename = "updated")]
+    Updated,
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+
+/// `project/changed` — a project was created, updated, or deleted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectChangedNotification {
+    #[serde(rename = "changeType")]
+    pub change_type: ProjectChangeType,
+    #[serde(rename = "projectId", default)]
+    pub project_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectRoot {
+    pub path: AbsolutePathBuf,
+}
+
+/// A user submission waiting in a thread's queue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueuedSubmission {
+    #[serde(rename = "clientUserMessageId", default)]
+    pub client_user_message_id: String,
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub input: Vec<UserInput>,
+}
+
+/// `autoApprovalReview/strictReviewRequired` — a strict review gate opened.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StrictReviewRequiredNotification {
+    /// Unix timestamp (ms) when this review started.
+    #[serde(rename = "startedAtMs", default)]
+    pub started_at_ms: i64,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    #[serde(rename = "turnId", default)]
+    pub turn_id: String,
+}
+
+/// `thread/project/updated` — a thread's project assignment changed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreadProjectUpdatedNotification {
+    #[serde(rename = "projectId", default)]
+    pub project_id: Option<String>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// `thread/queue/changed` — the thread's queued submissions changed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreadQueueChangedNotification {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// `thread/reverted` — the thread was rolled back.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreadRevertedNotification {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SandboxMode {
     #[serde(rename = "read-only")]
@@ -6298,6 +6464,10 @@ pub struct Thread {
     pub forked_from_id: Option<String>,
     #[serde(rename = "gitInfo", default, skip_serializing_if = "Option::is_none")]
     pub git_info: Option<GitInfo>,
+    /// Canonical project assignment owned by app-server, if any. Required
+    /// upstream from 0.147 but kept tolerant for pre-project servers.
+    #[serde(rename = "projectId", default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
     #[serde(default)]
     pub id: String,
     #[serde(rename = "modelProvider", default)]
@@ -6679,6 +6849,8 @@ pub enum ThreadItem {
     },
     #[serde(rename = "agentMessage")]
     AgentMessage {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        delivery: Option<AgentMessageDelivery>,
         id: String,
         #[serde(
             rename = "memoryCitation",

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -4481,6 +4481,26 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/reverted"
+              ],
+              "title": "Thread/revertedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadRevertedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/revertedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "skills/changed"
               ],
               "title": "Skills/changedNotificationMethod",
@@ -4555,6 +4575,66 @@
             "params"
           ],
           "title": "Thread/goal/clearedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/queue/changed"
+              ],
+              "title": "Thread/queue/changedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadQueueChangedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/queue/changedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "project/changed"
+              ],
+              "title": "Project/changedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ProjectChangedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Project/changedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/project/updated"
+              ],
+              "title": "Thread/project/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadProjectUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/project/updatedNotification",
           "type": "object"
         },
         {
@@ -4815,6 +4895,26 @@
             "params"
           ],
           "title": "Item/autoApprovalReview/completedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "autoApprovalReview/strictReviewRequired"
+              ],
+              "title": "AutoApprovalReview/strictReviewRequiredNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/StrictReviewRequiredNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "AutoApprovalReview/strictReviewRequiredNotification",
           "type": "object"
         },
         {
@@ -6468,6 +6568,12 @@
         },
         "type": "object"
       },
+      "AgentMessageDelivery": {
+        "enum": [
+          "async"
+        ],
+        "type": "string"
+      },
       "AgentMessageDeltaNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -7523,6 +7629,15 @@
           }
         ]
       },
+      "CliAuthCredentialsStoreMode": {
+        "enum": [
+          "file",
+          "keyring",
+          "auto",
+          "ephemeral"
+        ],
+        "type": "string"
+      },
       "CodexErrorInfo": {
         "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
         "oneOf": [
@@ -7533,6 +7648,7 @@
               "usageLimitExceeded",
               "serverOverloaded",
               "cyberPolicy",
+              "misalignmentPolicyViolation",
               "internalServerError",
               "unauthorized",
               "badRequest",
@@ -8881,10 +8997,26 @@
               }
             ]
           },
+          "chatgptBaseUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "checkForUpdateOnStartup": {
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "cliAuthCredentialsStore": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/CliAuthCredentialsStoreMode"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "computerUse": {
@@ -11830,12 +11962,89 @@
       "HookHandlerType": {
         "enum": [
           "command",
+          "mcpTool",
           "prompt",
           "agent"
         ],
         "type": "string"
       },
       "HookMetadata": {
+        "oneOf": [
+          {
+            "properties": {
+              "async": {
+                "default": false,
+                "type": "boolean"
+              },
+              "command": {
+                "type": "string"
+              },
+              "handlerType": {
+                "enum": [
+                  "command"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "command",
+              "handlerType"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "handlerType": {
+                "enum": [
+                  "mcpTool"
+                ],
+                "type": "string"
+              },
+              "server": {
+                "type": "string"
+              },
+              "tool": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "handlerType",
+              "server",
+              "tool"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "handlerType": {
+                "enum": [
+                  "prompt"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "handlerType"
+            ],
+            "title": "PromptHookMetadata",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "handlerType": {
+                "enum": [
+                  "agent"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "handlerType"
+            ],
+            "title": "AgentHookMetadata",
+            "type": "object"
+          }
+        ],
         "properties": {
           "additionalContextLimit": {
             "description": "Configured `additionalContext` spill threshold. `null` uses 2,500 tokens; `0` disables spilling.",
@@ -11843,12 +12052,6 @@
             "minimum": 0.0,
             "type": [
               "integer",
-              "null"
-            ]
-          },
-          "command": {
-            "type": [
-              "string",
               "null"
             ]
           },
@@ -11864,17 +12067,6 @@
           },
           "eventName": {
             "$ref": "#/definitions/v2/HookEventName"
-          },
-          "executionMode": {
-            "allOf": [
-              {
-                "$ref": "#/definitions/v2/HookExecutionMode"
-              }
-            ],
-            "default": "sync"
-          },
-          "handlerType": {
-            "$ref": "#/definitions/v2/HookHandlerType"
           },
           "isManaged": {
             "type": "boolean"
@@ -11920,7 +12112,6 @@
           "displayOrder",
           "enabled",
           "eventName",
-          "handlerType",
           "isManaged",
           "key",
           "source",
@@ -13110,6 +13301,19 @@
       "McpResourceReadParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "connectorId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "originCallId": {
+            "description": "Originating MCP tool call used to select the resource's app.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "server": {
             "type": "string"
           },
@@ -13138,6 +13342,13 @@
               "$ref": "#/definitions/v2/ResourceContent"
             },
             "type": "array"
+          },
+          "originCallId": {
+            "description": "Originating call when the server applied app-specific resource scoping.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -14021,6 +14232,14 @@
               "null"
             ]
           },
+          "retirementAt": {
+            "description": "Informational Unix timestamp for this upgrade's scheduled retirement, if known.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "upgradeCopy": {
             "type": [
               "string",
@@ -14510,6 +14729,8 @@
           "enterprise_cbp_usage_based",
           "enterprise",
           "edu",
+          "edu_plus",
+          "edu_pro",
           "unknown"
         ],
         "type": "string"
@@ -15899,6 +16120,108 @@
         "required": [
           "cols",
           "rows"
+        ],
+        "type": "object"
+      },
+      "Project": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "roots": {
+            "items": {
+              "$ref": "#/definitions/v2/ProjectRoot"
+            },
+            "type": "array"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "createdAt",
+          "id",
+          "metadata",
+          "name",
+          "position",
+          "roots",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "ProjectChangeType": {
+        "enum": [
+          "created",
+          "updated",
+          "deleted"
+        ],
+        "type": "string"
+      },
+      "ProjectChangedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "changeType": {
+            "$ref": "#/definitions/v2/ProjectChangeType"
+          },
+          "projectId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "changeType",
+          "projectId"
+        ],
+        "title": "ProjectChangedNotification",
+        "type": "object"
+      },
+      "ProjectRoot": {
+        "properties": {
+          "path": {
+            "$ref": "#/definitions/v2/AbsolutePathBuf"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "QueuedSubmission": {
+        "properties": {
+          "clientUserMessageId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "items": {
+              "$ref": "#/definitions/v2/UserInput"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "clientUserMessageId",
+          "id",
+          "input"
         ],
         "type": "object"
       },
@@ -18490,6 +18813,29 @@
         ],
         "type": "object"
       },
+      "StrictReviewRequiredNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "startedAtMs": {
+            "description": "Unix timestamp (in milliseconds) when this review started.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "turnId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "startedAtMs",
+          "threadId",
+          "turnId"
+        ],
+        "title": "StrictReviewRequiredNotification",
+        "type": "object"
+      },
       "SubAgentActivityKind": {
         "enum": [
           "started",
@@ -18761,6 +19107,13 @@
             "description": "Usually the first user message in the thread, if available.",
             "type": "string"
           },
+          "projectId": {
+            "description": "Canonical project assignment owned by app-server, if any.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "recencyAt": {
             "description": "Unix timestamp (in seconds) used for thread recency ordering.",
             "format": "int64",
@@ -18842,6 +19195,7 @@
           "id",
           "modelProvider",
           "preview",
+          "projectId",
           "sessionId",
           "source",
           "status",
@@ -19453,6 +19807,17 @@
           },
           {
             "properties": {
+              "delivery": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/AgentMessageDelivery"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "id": {
                 "type": "string"
               },
@@ -20476,6 +20841,39 @@
         "title": "ThreadNameUpdatedNotification",
         "type": "object"
       },
+      "ThreadProjectUpdatedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "projectId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "projectId",
+          "threadId"
+        ],
+        "title": "ThreadProjectUpdatedNotification",
+        "type": "object"
+      },
+      "ThreadQueueChangedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadQueueChangedNotification",
+        "type": "object"
+      },
       "ThreadReadParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -20966,6 +21364,19 @@
           "thread"
         ],
         "title": "ThreadResumeResponse",
+        "type": "object"
+      },
+      "ThreadRevertedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadRevertedNotification",
         "type": "object"
       },
       "ThreadRollbackParams": {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -313,6 +313,12 @@
       },
       "type": "object"
     },
+    "AgentMessageDelivery": {
+      "enum": [
+        "async"
+      ],
+      "type": "string"
+    },
     "AgentMessageDeltaNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -1367,6 +1373,15 @@
           "type": "object"
         }
       ]
+    },
+    "CliAuthCredentialsStoreMode": {
+      "enum": [
+        "file",
+        "keyring",
+        "auto",
+        "ephemeral"
+      ],
+      "type": "string"
     },
     "ClientInfo": {
       "properties": {
@@ -3691,6 +3706,7 @@
             "usageLimitExceeded",
             "serverOverloaded",
             "cyberPolicy",
+            "misalignmentPolicyViolation",
             "internalServerError",
             "unauthorized",
             "badRequest",
@@ -5039,10 +5055,26 @@
             }
           ]
         },
+        "chatgptBaseUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "checkForUpdateOnStartup": {
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "cliAuthCredentialsStore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CliAuthCredentialsStoreMode"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "computerUse": {
@@ -8099,12 +8131,89 @@
     "HookHandlerType": {
       "enum": [
         "command",
+        "mcpTool",
         "prompt",
         "agent"
       ],
       "type": "string"
     },
     "HookMetadata": {
+      "oneOf": [
+        {
+          "properties": {
+            "async": {
+              "default": false,
+              "type": "boolean"
+            },
+            "command": {
+              "type": "string"
+            },
+            "handlerType": {
+              "enum": [
+                "command"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "handlerType"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "handlerType": {
+              "enum": [
+                "mcpTool"
+              ],
+              "type": "string"
+            },
+            "server": {
+              "type": "string"
+            },
+            "tool": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "handlerType",
+            "server",
+            "tool"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "handlerType": {
+              "enum": [
+                "prompt"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "handlerType"
+          ],
+          "title": "PromptHookMetadata",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "handlerType": {
+              "enum": [
+                "agent"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "handlerType"
+          ],
+          "title": "AgentHookMetadata",
+          "type": "object"
+        }
+      ],
       "properties": {
         "additionalContextLimit": {
           "description": "Configured `additionalContext` spill threshold. `null` uses 2,500 tokens; `0` disables spilling.",
@@ -8112,12 +8221,6 @@
           "minimum": 0.0,
           "type": [
             "integer",
-            "null"
-          ]
-        },
-        "command": {
-          "type": [
-            "string",
             "null"
           ]
         },
@@ -8133,17 +8236,6 @@
         },
         "eventName": {
           "$ref": "#/definitions/HookEventName"
-        },
-        "executionMode": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/HookExecutionMode"
-            }
-          ],
-          "default": "sync"
-        },
-        "handlerType": {
-          "$ref": "#/definitions/HookHandlerType"
         },
         "isManaged": {
           "type": "boolean"
@@ -8189,7 +8281,6 @@
         "displayOrder",
         "enabled",
         "eventName",
-        "handlerType",
         "isManaged",
         "key",
         "source",
@@ -9440,6 +9531,19 @@
     "McpResourceReadParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "connectorId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "originCallId": {
+          "description": "Originating MCP tool call used to select the resource's app.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "server": {
           "type": "string"
         },
@@ -9468,6 +9572,13 @@
             "$ref": "#/definitions/ResourceContent"
           },
           "type": "array"
+        },
+        "originCallId": {
+          "description": "Originating call when the server applied app-specific resource scoping.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -10351,6 +10462,14 @@
             "null"
           ]
         },
+        "retirementAt": {
+          "description": "Informational Unix timestamp for this upgrade's scheduled retirement, if known.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "upgradeCopy": {
           "type": [
             "string",
@@ -10840,6 +10959,8 @@
         "enterprise_cbp_usage_based",
         "enterprise",
         "edu",
+        "edu_plus",
+        "edu_pro",
         "unknown"
       ],
       "type": "string"
@@ -12229,6 +12350,108 @@
       "required": [
         "cols",
         "rows"
+      ],
+      "type": "object"
+    },
+    "Project": {
+      "properties": {
+        "createdAt": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "position": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "roots": {
+          "items": {
+            "$ref": "#/definitions/ProjectRoot"
+          },
+          "type": "array"
+        },
+        "updatedAt": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "createdAt",
+        "id",
+        "metadata",
+        "name",
+        "position",
+        "roots",
+        "updatedAt"
+      ],
+      "type": "object"
+    },
+    "ProjectChangeType": {
+      "enum": [
+        "created",
+        "updated",
+        "deleted"
+      ],
+      "type": "string"
+    },
+    "ProjectChangedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "changeType": {
+          "$ref": "#/definitions/ProjectChangeType"
+        },
+        "projectId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "changeType",
+        "projectId"
+      ],
+      "title": "ProjectChangedNotification",
+      "type": "object"
+    },
+    "ProjectRoot": {
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "QueuedSubmission": {
+      "properties": {
+        "clientUserMessageId": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "input": {
+          "items": {
+            "$ref": "#/definitions/UserInput"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "clientUserMessageId",
+        "id",
+        "input"
       ],
       "type": "object"
     },
@@ -14451,6 +14674,26 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/reverted"
+              ],
+              "title": "Thread/revertedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadRevertedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/revertedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "skills/changed"
               ],
               "title": "Skills/changedNotificationMethod",
@@ -14525,6 +14768,66 @@
             "params"
           ],
           "title": "Thread/goal/clearedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/queue/changed"
+              ],
+              "title": "Thread/queue/changedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadQueueChangedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/queue/changedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "project/changed"
+              ],
+              "title": "Project/changedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ProjectChangedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Project/changedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/project/updated"
+              ],
+              "title": "Thread/project/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadProjectUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/project/updatedNotification",
           "type": "object"
         },
         {
@@ -14785,6 +15088,26 @@
             "params"
           ],
           "title": "Item/autoApprovalReview/completedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "autoApprovalReview/strictReviewRequired"
+              ],
+              "title": "AutoApprovalReview/strictReviewRequiredNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/StrictReviewRequiredNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "AutoApprovalReview/strictReviewRequiredNotification",
           "type": "object"
         },
         {
@@ -16242,6 +16565,29 @@
       ],
       "type": "object"
     },
+    "StrictReviewRequiredNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "startedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when this review started.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "startedAtMs",
+        "threadId",
+        "turnId"
+      ],
+      "title": "StrictReviewRequiredNotification",
+      "type": "object"
+    },
     "SubAgentActivityKind": {
       "enum": [
         "started",
@@ -16513,6 +16859,13 @@
           "description": "Usually the first user message in the thread, if available.",
           "type": "string"
         },
+        "projectId": {
+          "description": "Canonical project assignment owned by app-server, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "recencyAt": {
           "description": "Unix timestamp (in seconds) used for thread recency ordering.",
           "format": "int64",
@@ -16594,6 +16947,7 @@
         "id",
         "modelProvider",
         "preview",
+        "projectId",
         "sessionId",
         "source",
         "status",
@@ -17205,6 +17559,17 @@
         },
         {
           "properties": {
+            "delivery": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AgentMessageDelivery"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
             "id": {
               "type": "string"
             },
@@ -18228,6 +18593,39 @@
       "title": "ThreadNameUpdatedNotification",
       "type": "object"
     },
+    "ThreadProjectUpdatedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "projectId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "projectId",
+        "threadId"
+      ],
+      "title": "ThreadProjectUpdatedNotification",
+      "type": "object"
+    },
+    "ThreadQueueChangedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadQueueChangedNotification",
+      "type": "object"
+    },
     "ThreadReadParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -18718,6 +19116,19 @@
         "thread"
       ],
       "title": "ThreadResumeResponse",
+      "type": "object"
+    },
+    "ThreadRevertedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadRevertedNotification",
       "type": "object"
     },
     "ThreadRollbackParams": {


### PR DESCRIPTION
Fixes #311 (nightly drift report) and completes the version-train move discussed earlier — 0.147.0 matches the installed CLI and **unstrands the per-thread usage types** merged at the already-published 0.146.4.

**Upstream changes absorbed** (11 new definitions, 11 changed):
- **Project surface**: `Project`/`ProjectRoot`/`ProjectChangeType`, `Thread.project_id` (kept tolerant for pre-project servers), notifications `project/changed` + `thread/project/updated`
- **Queue/revert/review notifications**: `thread/queue/changed` (`QueuedSubmission`), `thread/reverted`, `autoApprovalReview/strictReviewRequired` — all five typed end-to-end (constants, `from_envelope`, `method()`, `into_envelope`)
- **mcpTool hooks**: `HookHandlerType::McpTool` + `server`/`tool`/`async` on `HookMetadata` (upstream restructured it as a tagged union; the flat tolerant struct absorbs it additively)
- Field adds: `chatgptBaseUrl`, `cliAuthCredentialsStore` (typed store-mode enum), `connectorId`/`originCallId` on MCP resource reads, `ModelUpgradeInfo.retirementAt`, `ThreadItem::AgentMessage.delivery`, `CodexErrorInfo::misalignmentPolicyViolation`, `PlanType` edu tiers

**Verification**: snapshots byte-identical per `scripts/check_codex_schema_drift.py`; 108 tests green; **live wirecheck codex tier green** against installed codex-cli 0.147.0. Publish-ready on merge (awaiting the publish word as usual).