### PR TITLE
claude-codes 2.1.233: export the transcript path-encoding rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.232"
+version = "2.1.233"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.232`, tested against Claude CLI `2.1.232`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.233`, tested against Claude CLI `2.1.232`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.147.0`, tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.18`, tested against opencode `1.18.18`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.233] - 2026-08-19
+
+### Added
+
+- **`transcript` module** — the CLI's unpublished on-disk transcript
+  path rule, exported so consumers stop growing private copies:
+  `encode_project_dir` (`/` and `.` → `-`, measured against real
+  transcript stores and pinned by tests, documented as lossy) and
+  `transcript_path(home, cwd, session_id)`, which takes `home`
+  explicitly so a test can never accidentally resolve into a real
+  `~/.claude`. Extracted at agent-portal's request to delete its
+  duplicate implementation.
+
 ## [2.1.232] - 2026-08-14
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.232"
+version = "2.1.233"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -107,6 +107,9 @@ pub mod protocol;
 pub mod tool_inputs;
 pub mod types;
 
+// On-disk transcript locations (the CLI's unpublished path-encoding rule)
+pub mod transcript;
+
 // Login support tooling (PTY-driven `claude auth login` / `setup-token`)
 #[cfg(feature = "auth")]
 pub mod auth;

--- a/claude-codes/src/transcript.rs
+++ b/claude-codes/src/transcript.rs
@@ -1,0 +1,91 @@
+//! On-disk transcript locations for Claude Code sessions.
+//!
+//! The CLI persists every session's journal at
+//! `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. The encoding rule
+//! is unpublished CLI behavior, measured against real transcript stores:
+//! every `/` and `.` in the working directory's path becomes `-`; all other
+//! characters pass through. Observed pairs:
+//!
+//! - `/home/u/repos/inboxnegative.com` → `-home-u-repos-inboxnegative-com`
+//! - `/home/u/repos/x/.worktrees/y` → `-home-u-repos-x--worktrees-y`
+//!
+//! **The encoding is lossy** (not injective): distinct working directories
+//! can collide — `a/b.c` and `a/b/c` and `a-b-c` all encode identically.
+//! Treat encoded names as a lookup key for paths you already know, never as
+//! something to decode.
+//!
+//! Exported so consumers stop growing private copies of the rule: a
+//! consumer that re-implements it can silently diverge the day the CLI
+//! changes, and two implementations of one CLI behavior is one too many.
+
+use std::path::{Path, PathBuf};
+
+/// Encode a working directory the way the CLI names its per-project
+/// transcript folder: `/` and `.` become `-`, everything else unchanged.
+pub fn encode_project_dir(working_directory: &Path) -> String {
+    working_directory
+        .to_string_lossy()
+        .chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect()
+}
+
+/// Resolve `<home>/.claude/projects/<encoded-cwd>/<session-id>.jsonl` —
+/// the transcript file the CLI writes for `session_id` runs in
+/// `working_directory`. Takes `home` explicitly (pass a tempdir in tests;
+/// never let a test path resolve into a real transcript store).
+pub fn transcript_path(
+    home: &Path,
+    working_directory: &Path,
+    session_id: impl AsRef<str>,
+) -> PathBuf {
+    home.join(".claude")
+        .join("projects")
+        .join(encode_project_dir(working_directory))
+        .join(format!("{}.jsonl", session_id.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pairs observed verbatim in a real ~/.claude/projects store.
+    #[test]
+    fn encoding_matches_observed_cli_behavior() {
+        for (dir, expect) in [
+            (
+                "/home/u/repos/rust-code-agent-sdks",
+                "-home-u-repos-rust-code-agent-sdks",
+            ),
+            (
+                "/home/u/repos/inboxnegative.com",
+                "-home-u-repos-inboxnegative-com",
+            ),
+            (
+                "/home/u/repos/x/.worktrees/y",
+                "-home-u-repos-x--worktrees-y",
+            ),
+            ("/tmp/reset-probe", "-tmp-reset-probe"),
+        ] {
+            assert_eq!(encode_project_dir(Path::new(dir)), expect);
+        }
+    }
+
+    #[test]
+    fn transcript_path_assembles_under_the_given_home() {
+        let p = transcript_path(Path::new("/fake/home"), Path::new("/work/dir.x"), "abc-123");
+        assert_eq!(
+            p,
+            Path::new("/fake/home/.claude/projects/-work-dir-x/abc-123.jsonl")
+        );
+    }
+
+    /// The rule is lossy — document-by-test so nobody builds a decoder.
+    #[test]
+    fn encoding_is_lossy_by_design() {
+        assert_eq!(
+            encode_project_dir(Path::new("/a/b.c")),
+            encode_project_dir(Path::new("/a/b/c")),
+        );
+    }
+}


### PR DESCRIPTION
agent-portal keeps a private copy of the CLI's unpublished transcript path-encoding (`/` and `.` → `-`) in `claude-session-lib/src/transcript.rs` to locate `~/.claude/projects/<encoded-cwd>/<id>.jsonl`. Two implementations of one CLI behavior can diverge silently the day the CLI changes, so the rule moves upstream at their request — they delete their copy and call ours.

- `transcript::encode_project_dir` — measured against real transcript stores (observed pairs pinned by tests, including `.com` and `/.worktrees` cases), documented and test-pinned as **lossy** so nobody attempts a decoder
- `transcript::transcript_path(home, cwd, session_id)` — `home` is an explicit parameter by design (the portal session's safety constraint): a harness that forgets its tempdir fixture gets a compile error instead of writing into a developer's real `~/.claude`

Also the first landed piece of the parked stub-CLI design — the materialization engine, if ever built, uses exactly these functions. 2.1.232 → 2.1.233 (crate-side addition, patch offset).