### PR TITLE
muse-codes 0.1.8: typed ToolCorrelationFacts on tool.result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each crate's version tracks the CLI it wraps:
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.233`, tested against Claude CLI `2.1.232`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.147.0`, tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.18`, tested against opencode `1.18.18`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.8`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 - **`antigravity-codes`** version tracks the `google-antigravity` wheel whose bundled harness it was generated from. Currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-08-19
+
+### Changed
+
+- **`ToolResult.correlation_facts` is typed** (`ToolCorrelationFacts
+  { tool_name, outcome, extra }`, fixes #310): the two fields consumers
+  key on — `tool_name` drives the `tool.<name>`-task attribution match,
+  `outcome` classifies the result — are now fields instead of `Value`
+  pokes, with `ToolResult::outcome()` / `tool_name()` accessors. Unknown
+  keys round-trip through a flattened `extra`, pinned by the corpus
+  byte-faithful round-trip tests. Filed by agent-portal to replace its
+  `correlation_facts.get("outcome")` poke.
+
 ## [0.1.7] - 2026-08-11
 
 ### Added

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -248,10 +248,11 @@ pub struct ToolResult {
     /// For the `bash`/`command` tool this is a JSON string of a [`CommandResult`];
     /// see [`ToolResult::command_result`] and [`ToolResult::try_command_result`].
     pub text: String,
-    /// Correlation summary — observed `{outcome, tool_name}`, open-shaped.
-    /// Absent on some results; treat as `None` when missing.
+    /// Correlation summary — typed over the observed `{outcome, tool_name}`
+    /// shape; unknown keys round-trip through `extra`. Absent on some
+    /// results; treat as `None` when missing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub correlation_facts: Option<Value>,
+    pub correlation_facts: Option<ToolCorrelationFacts>,
     /// Populated for file-editing tools; open-shaped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_facts: Option<Value>,
@@ -259,17 +260,45 @@ pub struct ToolResult {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// Typed view of `tool.result`'s `correlation_facts` — the fields consumers
+/// key on: `tool_name` drives the `tool.<name>`-task attribution match, and
+/// `outcome` classifies the result. Every field is optional and unknown
+/// keys round-trip via `extra`, so a wire addition widens rather than
+/// breaks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ToolCorrelationFacts {
+    /// Tool that produced this result (matches the `tool.<tool_name>` task
+    /// kind). Observed values: `write_file`, `read_file`, `bash`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    /// `"success"` or `"failure"` as observed on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+impl ToolResult {
+    /// The result's `correlation_facts.outcome`, when carried.
+    pub fn outcome(&self) -> Option<&str> {
+        self.correlation_facts
+            .as_ref()
+            .and_then(|f| f.outcome.as_deref())
+    }
+
+    /// The result's `correlation_facts.tool_name`, when carried.
+    pub fn tool_name(&self) -> Option<&str> {
+        self.correlation_facts
+            .as_ref()
+            .and_then(|f| f.tool_name.as_deref())
+    }
+}
+
 impl ToolResult {
     /// Whether this result came from the `bash`/`command` tool, via
     /// `correlation_facts.tool_name == "bash" | "command"`.
     pub fn is_command_tool(&self) -> bool {
-        matches!(
-            self.correlation_facts
-                .as_ref()
-                .and_then(|v| v.get("tool_name"))
-                .and_then(|v| v.as_str()),
-            Some("bash" | "command")
-        )
+        matches!(self.tool_name(), Some("bash" | "command"))
     }
 
     /// Try to parse `text` as a structured [`CommandResult`] (the `bash` tool
@@ -502,7 +531,10 @@ mod tests {
         assert!(result.command_result().is_none());
         assert!(result.try_command_result().is_err());
 
-        result.correlation_facts = Some(json!({ "tool_name": "write_file" }));
+        result.correlation_facts = Some(ToolCorrelationFacts {
+            tool_name: Some("write_file".into()),
+            ..Default::default()
+        });
         assert!(!result.is_command_tool());
     }
 }

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -51,7 +51,8 @@ pub use error::{Error, Result};
 pub use io::{
     CommandAccepted, CommandResult, Durability, ModelConfigured, MusePayload, MuseRecord,
     RecordType, RunOutputDelta, RunStarted, RunTerminal, SessionRunLinked, StreamKind, StreamRef,
-    TaskLifecycle, TaskLifecycleEvent, TaskStreamLinked, ToolResult, TurnInputUser,
+    TaskLifecycle, TaskLifecycleEvent, TaskStreamLinked, ToolCorrelationFacts, ToolResult,
+    TurnInputUser,
 };
 
 #[cfg(feature = "async-client")]


### PR DESCRIPTION
Fixes #310 (agent-portal's ask, filed to unblock replacing its `correlation_facts.get("outcome")` poke).

- `ToolCorrelationFacts { tool_name, outcome, extra }` — shape derived from every committed capture (only those two keys observed; outcomes `success`/`failure`); all fields optional, unknown keys round-trip via flattened `extra` so wire additions widen rather than break
- Accessors `ToolResult::outcome()` / `tool_name()`; `is_command_tool` now reads through them; `command_result()` untouched
- Byte-faithful round-trips pinned by the existing corpus tests (all green)

0.1.7 → 0.1.8.