### PR TITLE
codex-codes: exec-style ExecEvent adapter and turn_steer helper

### DIFF
--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`events` module** (fixes #213): `ExecEvent` — a stable, serializable
+  exec-JSONL-style view over app-server notifications
+  (`thread.started` / `turn.started|completed|failed` /
+  `item.started|completed` / `item.agentMessage.delta` /
+  `thread.tokenUsage`), with everything unmapped passing through as
+  `ExecEvent::Raw { method, params }` so future notifications degrade to
+  raw rather than disappearing. Removes downstream renderers' hand-rolled
+  synthetic event structs.
+- **`AsyncClient::turn_steer`** (with `thread_resume`, completes #202):
+  the last app-server lifecycle call agent-portal still drove through
+  raw `request::<>` + `methods::*`. A live test pins `thread_resume`
+  reopening a persisted thread across an app-server restart with its
+  typed response decoding.
+
 - **Project surface** (upstream 0.147): `Project`/`ProjectRoot`/
   `ProjectChangeType` types, `Thread.project_id`, and typed notifications
   `project/changed` and `thread/project/updated`.

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -53,6 +53,7 @@ use crate::protocol::{
     ThreadDeleteParams, ThreadDeleteResponse, ThreadForkParams, ThreadForkResponse,
     ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
     TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
+    TurnSteerParams, TurnSteerResponse,
 };
 use crate::protocol_generated::types::{
     CancelLoginAccountParams, CancelLoginAccountResponse, GetAccountParams,
@@ -284,6 +285,13 @@ impl AsyncClient {
     /// to stream notifications until `turn/completed` arrives.
     pub async fn turn_start(&mut self, params: &TurnStartParams) -> Result<TurnStartResponse> {
         self.request(crate::protocol::methods::TURN_START, params)
+            .await
+    }
+
+    /// Steer an active turn with additional user input (`turn/steer`) —
+    /// appends to the running turn instead of starting a new one.
+    pub async fn turn_steer(&mut self, params: &TurnSteerParams) -> Result<TurnSteerResponse> {
+        self.request(crate::protocol::methods::TURN_STEER, params)
             .await
     }
 

--- a/codex-codes/src/events.rs
+++ b/codex-codes/src/events.rs
@@ -1,0 +1,193 @@
+//! Exec-style event view over app-server notifications (issue #213).
+//!
+//! Downstream renderers (agent-portal's codex-session-lib was the filing
+//! consumer) want a stable, serializable event stream in the shape of the
+//! CLI's `codex exec` JSONL — without hand-rolling a synthetic struct per
+//! notification and re-serializing typed items back into JSON. This module
+//! is that adapter: [`ExecEvent::from_notification`] maps the lifecycle
+//! notifications renderers actually draw onto tagged, serde-stable events,
+//! and passes everything else through as [`ExecEvent::Raw`] with its wire
+//! method and params preserved — unknown future notifications degrade to
+//! raw, never disappear.
+
+use crate::messages::Notification;
+use crate::protocol_generated::types::{Thread, ThreadItem, ThreadTokenUsage, Turn, TurnError};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One renderable event, tagged in `codex exec` JSONL style.
+///
+/// Typed payloads (`ThreadItem`, `Turn`, …) are embedded directly — they
+/// already serialize to their wire shapes, so consumers get stable JSON
+/// without a re-serialization layer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ExecEvent {
+    #[serde(rename = "thread.started")]
+    ThreadStarted { thread: Thread },
+    #[serde(rename = "turn.started")]
+    TurnStarted { thread_id: String, turn: Turn },
+    #[serde(rename = "turn.completed")]
+    TurnCompleted { thread_id: String, turn: Turn },
+    /// A turn-scoped error (`error` notification) — the closest app-server
+    /// analog to exec's `turn.failed`.
+    #[serde(rename = "turn.failed")]
+    TurnFailed {
+        thread_id: String,
+        turn_id: String,
+        error: TurnError,
+    },
+    #[serde(rename = "item.started")]
+    ItemStarted {
+        thread_id: String,
+        started_at_ms: i64,
+        item: ThreadItem,
+    },
+    #[serde(rename = "item.completed")]
+    ItemCompleted {
+        thread_id: String,
+        completed_at_ms: i64,
+        item: ThreadItem,
+    },
+    /// Streamed agent-message text for the active item.
+    #[serde(rename = "item.agentMessage.delta")]
+    AgentMessageDelta {
+        thread_id: String,
+        item_id: String,
+        delta: String,
+    },
+    /// Per-turn token accounting (`thread/tokenUsage/updated`).
+    #[serde(rename = "thread.tokenUsage")]
+    TokenUsage {
+        thread_id: String,
+        turn_id: String,
+        token_usage: ThreadTokenUsage,
+    },
+    /// Any notification without a first-class mapping above — including
+    /// methods newer than these bindings. The wire method and params are
+    /// preserved verbatim so nothing is droppable-by-default.
+    #[serde(rename = "raw")]
+    Raw {
+        method: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        params: Option<Value>,
+    },
+}
+
+impl ExecEvent {
+    /// Map one notification onto its exec-style event. Never fails and
+    /// never drops: lifecycle notifications get first-class variants,
+    /// everything else round-trips through [`ExecEvent::Raw`].
+    pub fn from_notification(notification: Notification) -> ExecEvent {
+        match notification {
+            Notification::ThreadStarted(n) => ExecEvent::ThreadStarted { thread: n.thread },
+            Notification::TurnStarted(n) => ExecEvent::TurnStarted {
+                thread_id: n.thread_id,
+                turn: n.turn,
+            },
+            Notification::TurnCompleted(n) => ExecEvent::TurnCompleted {
+                thread_id: n.thread_id,
+                turn: n.turn,
+            },
+            Notification::Error(n) => ExecEvent::TurnFailed {
+                thread_id: n.thread_id,
+                turn_id: n.turn_id,
+                error: n.error,
+            },
+            Notification::ItemStarted(n) => ExecEvent::ItemStarted {
+                thread_id: n.thread_id,
+                started_at_ms: n.started_at_ms,
+                item: n.item,
+            },
+            Notification::ItemCompleted(n) => ExecEvent::ItemCompleted {
+                thread_id: n.thread_id,
+                completed_at_ms: n.completed_at_ms,
+                item: n.item,
+            },
+            Notification::AgentMessageDelta(n) => ExecEvent::AgentMessageDelta {
+                thread_id: n.thread_id,
+                item_id: n.item_id,
+                delta: n.delta,
+            },
+            Notification::ThreadTokenUsageUpdated(n) => ExecEvent::TokenUsage {
+                thread_id: n.thread_id,
+                turn_id: n.turn_id,
+                token_usage: n.token_usage,
+            },
+            other => {
+                let method = other.method().to_string();
+                match other.into_envelope() {
+                    Ok((_, params)) => ExecEvent::Raw { method, params },
+                    // Serialization of our own typed structs failing would be
+                    // a bindings bug; surface the method rather than nothing.
+                    Err(_) => ExecEvent::Raw {
+                        method,
+                        params: None,
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lifecycle notifications map to exec-tagged events whose JSON shape
+    /// is stable (`type` tag in exec JSONL style).
+    #[test]
+    fn item_completed_maps_to_exec_tagged_json() {
+        let n = Notification::from_envelope(
+            "item/completed",
+            Some(serde_json::json!({
+                "threadId": "t-1",
+                "completedAtMs": 5,
+                "item": {"type": "agentMessage", "id": "i-1", "text": "hi"}
+            })),
+        )
+        .expect("typed notification");
+        let event = ExecEvent::from_notification(n);
+        let v = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(v["type"], "item.completed");
+        assert_eq!(v["thread_id"], "t-1");
+        assert_eq!(v["item"]["type"], "agentMessage");
+        assert_eq!(v["item"]["text"], "hi");
+    }
+
+    /// Unknown methods pass through with method + params preserved — a
+    /// newer CLI's notification degrades to raw, never disappears.
+    #[test]
+    fn unknown_notification_passes_through_raw() {
+        let n = Notification::from_envelope("somefuture/thing", Some(serde_json::json!({"x": 1})))
+            .expect("unknown routes to Unknown without error");
+        let event = ExecEvent::from_notification(n);
+        match &event {
+            ExecEvent::Raw { method, params } => {
+                assert_eq!(method, "somefuture/thing");
+                assert_eq!(params.as_ref().unwrap()["x"], 1);
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+        let v = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(v["type"], "raw");
+    }
+
+    /// A typed-but-unmapped notification (no first-class exec variant) also
+    /// rides Raw, keeping its wire method — nothing is droppable-by-default.
+    #[test]
+    fn typed_but_unmapped_notification_rides_raw_with_its_method() {
+        let n = Notification::from_envelope(
+            "thread/reverted",
+            Some(serde_json::json!({"threadId": "t-9"})),
+        )
+        .expect("typed");
+        match ExecEvent::from_notification(n) {
+            ExecEvent::Raw { method, params } => {
+                assert_eq!(method, "thread/reverted");
+                assert_eq!(params.unwrap()["threadId"], "t-9");
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+    }
+}

--- a/codex-codes/src/events.rs
+++ b/codex-codes/src/events.rs
@@ -20,6 +20,10 @@ use serde_json::Value;
 /// Typed payloads (`ThreadItem`, `Turn`, …) are embedded directly — they
 /// already serialize to their wire shapes, so consumers get stable JSON
 /// without a re-serialization layer.
+// Thread/ThreadItem payloads dwarf Raw. Like the Notification enum itself,
+// this is a transient per-frame classification consumers unpack promptly;
+// boxing would tax every construction/match site for no retained-memory win.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ExecEvent {

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -107,6 +107,7 @@
 pub mod io;
 
 pub mod error;
+pub mod events;
 pub mod jsonrpc;
 pub mod messages;
 pub mod models;

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -613,6 +613,11 @@ async fn test_typed_message_audit_strict() {
                     Notification::ThreadEnvironmentDisconnected(_) => {
                         "ThreadEnvironmentDisconnected"
                     }
+                    Notification::StrictReviewRequired(_) => "StrictReviewRequired",
+                    Notification::ProjectChanged(_) => "ProjectChanged",
+                    Notification::ThreadProjectUpdated(_) => "ThreadProjectUpdated",
+                    Notification::ThreadQueueChanged(_) => "ThreadQueueChanged",
+                    Notification::ThreadReverted(_) => "ThreadReverted",
                     Notification::ThreadRealtimeClosed(_) => "ThreadRealtimeClosed",
                     Notification::ThreadRealtimeError(_) => "ThreadRealtimeError",
                     Notification::ThreadRealtimeItemAdded(_) => "ThreadRealtimeItemAdded",
@@ -917,4 +922,69 @@ fn test_auth_status_local_parses_real_file() {
         );
         assert!(s.account_id.is_some());
     }
+}
+
+/// thread/resume reopens a persisted thread through the typed helper (no
+/// methods::* or raw request::<> needed downstream) and its response
+/// decodes: the resumed thread carries the same id and replays into a
+/// working turn.
+#[tokio::test]
+async fn test_thread_resume_reopens_thread_via_typed_helper() {
+    let mut client = AsyncClient::start().await.expect("start app-server");
+    let source = client
+        .thread_start(&ThreadStartParams::default())
+        .await
+        .expect("thread_start");
+    client
+        .turn_start(&TurnStartParams {
+            thread_id: source.thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "Remember the word 'garnet'. Reply with just OK.".to_string(),
+                text_elements: None,
+            }],
+            approval_policy: None,
+            approvals_reviewer: None,
+            client_user_message_id: None,
+            cwd: None,
+            effort: None,
+            model: None,
+            output_schema: None,
+            personality: None,
+            sandbox_policy: None,
+            service_tier: None,
+            summary: None,
+        })
+        .await
+        .expect("seed turn");
+    let mut n = 0;
+    while let Some(msg) = client.next_message().await.expect("read") {
+        n += 1;
+        match msg {
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => break,
+            ServerMessage::Request { id, .. } => {
+                client
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
+                    .await
+                    .expect("respond");
+            }
+            _ => {}
+        }
+        assert!(n < 200, "seed turn runaway");
+    }
+    client.shutdown().await.expect("shutdown source");
+
+    // Fresh app-server process: resume must rehydrate from persistence.
+    let mut resumed = AsyncClient::start().await.expect("restart app-server");
+    let response = resumed
+        .thread_resume(
+            &serde_json::from_value(serde_json::json!({ "threadId": source.thread.id }))
+                .expect("resume params"),
+        )
+        .await
+        .expect("thread_resume decodes");
+    assert_eq!(
+        response.thread.id, source.thread.id,
+        "resume must reopen the SAME thread id"
+    );
+    resumed.shutdown().await.expect("shutdown resumed");
 }


### PR DESCRIPTION
Fixes #213, completes #202 — both riding the still-unpublished 0.147.0, so no extra version bump.

**#213 — `events::ExecEvent`**: stable, serializable exec-JSONL-style view over app-server notifications. Lifecycle notifications (`thread.started`, `turn.started/completed/failed`, `item.started/completed`, `item.agentMessage.delta`, `thread.tokenUsage`) get first-class tagged variants with typed payloads (`ThreadItem`, `Turn`) embedded directly — no re-serialization layer. Everything unmapped (including future CLI notifications) passes through as `Raw { method, params }`: degrade-to-raw, never drop. Three tests pin the tagged JSON shape, unknown passthrough, and typed-but-unmapped passthrough. agent-portal can delete its synthetic event structs (`ItemEvent`/`PassthroughEvent`/`TurnCompletedEvent`/…).

**#202 — `turn_steer`**: `thread_resume` was already on the client (landed since filing); `turn/steer` was the one lifecycle call agent-portal still drives via `methods::* + request::<>`. Now a typed helper. Acceptance test added as required: a live test proving `thread_resume` reopens a persisted thread **across an app-server restart** with its typed response decoding (same thread id back).

Also: the strict live typed-audit gains match arms for the five 0.147 notifications.