### PR TITLE
Expose tested_cli_version() from every crate, CI-lockstepped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,29 @@ jobs:
           else
             echo "✅ README.md has muse-codes $MUSE_VERSION"
           fi
+          # Machine-readable pins must match the READMEs (tested_cli_version)
+          CODEX_CONST=$(grep 'const TESTED_VERSION' codex-codes/src/version.rs | grep -oP '\d+\.\d+\.\d+')
+          if [ "$CODEX_CONST" != "$CODEX_TESTED" ]; then
+            echo "❌ codex version.rs TESTED_VERSION ($CODEX_CONST) != README tested ($CODEX_TESTED)"
+            FAILED=1
+          else
+            echo "✅ codex tested_cli_version matches README"
+          fi
+          MUSE_CONST=$(grep -A2 'fn tested_cli_version' muse-codes/src/version.rs | grep -oP '"\K[0-9.]+' | head -1)
+          if [ "$MUSE_CONST" != "$MUSE_TESTED" ]; then
+            echo "❌ muse version.rs tested_cli_version ($MUSE_CONST) != README tested ($MUSE_TESTED)"
+            FAILED=1
+          else
+            echo "✅ muse tested_cli_version matches README"
+          fi
+          OPENCODE_CONST=$(grep -A2 'fn tested_cli_version' opencode-codes/src/version.rs | grep -oP '"\K[0-9.]+' | head -1)
+          if [ "$OPENCODE_CONST" != "$OPENCODE_TESTED" ]; then
+            echo "❌ opencode version.rs tested_cli_version ($OPENCODE_CONST) != README tested ($OPENCODE_TESTED)"
+            FAILED=1
+          else
+            echo "✅ opencode tested_cli_version matches README"
+          fi
+
           if ! grep -q "tested against Muse Code.*$MUSE_TESTED" README.md; then
             echo "❌ README.md missing Muse Code tested version $MUSE_TESTED"
             FAILED=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           CLAUDE_VERSION=$(grep '^version' claude-codes/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CODEX_VERSION=$(grep '^version' codex-codes/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CLAUDE_TESTED=$(grep 'const TESTED_VERSION' claude-codes/src/version.rs | grep -oP '\d+\.\d+\.\d+')
-          CODEX_TESTED=$(grep 'Tested against.*Codex CLI' codex-codes/README.md | grep -oP '\d+\.\d+\.\d+')
+          CODEX_TESTED=$(grep 'Tested against.*Codex CLI' codex-codes/README.md | grep -oP '\d+\.\d+\.\d+' | head -1)
           OPENCODE_VERSION=$(grep '^version' opencode-codes/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           OPENCODE_TESTED=$(grep 'Tested against.*opencode' opencode-codes/README.md | grep -oP '\d+\.\d+\.\d+')
 
@@ -226,7 +226,7 @@ jobs:
           else
             echo "✅ codex tested_cli_version matches README"
           fi
-          MUSE_CONST=$(grep -A2 'fn tested_cli_version' muse-codes/src/version.rs | grep -oP '"\K[0-9.]+' | head -1)
+          MUSE_CONST=$(grep 'TESTED_MUSE_VERSION: &str' muse-codes/src/version.rs | grep -oP '"\K[0-9.]+')
           if [ "$MUSE_CONST" != "$MUSE_TESTED" ]; then
             echo "❌ muse version.rs tested_cli_version ($MUSE_CONST) != README tested ($MUSE_TESTED)"
             FAILED=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.233"
+version = "2.1.234"
 dependencies = [
  "anyhow",
  "base64",
@@ -1296,7 +1296,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opencode-codes"
-version = "1.18.18"
+version = "1.18.19"
 dependencies = [
  "futures-core",
  "jsonschema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "atomic-waker"
@@ -499,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1482,7 +1482,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1811,7 +1811,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2684,7 +2684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.233` (tested CLI + 1 crate-side patch), tested against Claude CLI `2.1.232`.
+- **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
 - **`codex-codes`** — currently `codex-codes 0.147.0`, tested against Codex CLI `0.147.0`.
-- **`opencode-codes`** — currently `opencode-codes 1.18.18`, tested against opencode `1.18.18`.
+- **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.1.8` (tested CLI + 8 crate-side patches), tested against Muse Code `0.1.0` (build `0.1.0-R708.1`; Meta has shipped no newer CLI).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).
 

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.234] - 2026-08-19
+
+### Added
+
+- **`version::tested_cli_version()`** — the tested-against CLI release,
+  machine-readable from the published artifact (previously a private
+  const only the runtime warning could see). CI keeps it in lockstep
+  with the README's `Tested against:` line.
+
 ## [2.1.233] - 2026-08-19
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.233"
+version = "2.1.234"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -8,6 +8,15 @@ use std::sync::Once;
 /// The latest Claude CLI version we've tested against
 const TESTED_VERSION: &str = "2.1.232";
 
+/// The Claude CLI release this crate's live integration suite last passed
+/// against — the machine-readable form of the crate's version convention
+/// (the crate version approximates this; crate-side patch offsets can push
+/// it past). Kept in lockstep with the README's `Tested against:` line by
+/// CI.
+pub fn tested_cli_version() -> &'static str {
+    TESTED_VERSION
+}
+
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`version::tested_cli_version()`** — the tested-against CLI release,
+  machine-readable from the published artifact. This also fixes the
+  runtime version check, whose private const had gone stale at 0.146.0
+  while the README said 0.147.0 — the exact drift the new CI lockstep
+  clause now prevents.
+
 - **`events` module** (fixes #213): `ExecEvent` — a stable, serializable
   exec-JSONL-style view over app-server notifications
   (`thread.started` / `turn.started|completed|failed` /

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,14 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.146.0";
+const TESTED_VERSION: &str = "0.147.0";
+
+/// The Codex CLI release this crate's live integration suite last passed
+/// against — the machine-readable form of the crate's version convention.
+/// Kept in lockstep with the README's `Tested against:` line by CI.
+pub fn tested_cli_version() -> &'static str {
+    TESTED_VERSION
+}
 
 /// Ensures version warning is only shown once per session.
 static VERSION_CHECK: Once = Once::new();

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.8] - 2026-08-19
 
+### Added
+
+- **`version::tested_cli_version()` / `tested_cli_build()`** — the
+  workspace-uniform accessors over the existing `TESTED_MUSE_VERSION` /
+  `TESTED_MUSE_BUILD` pins, so every crate answers the same question the
+  same way.
+
 ### Changed
 
 - **`ToolResult.correlation_facts` is typed** (`ToolCorrelationFacts

--- a/muse-codes/src/version.rs
+++ b/muse-codes/src/version.rs
@@ -9,3 +9,16 @@ pub const TESTED_MUSE_BUILD: &str = "0.1.0-R708.1";
 
 /// Envelope `schema_version` the models target.
 pub const STREAM_SCHEMA_VERSION: u32 = 1;
+
+/// The tested-against CLI release — the workspace-uniform accessor
+/// (`tested_cli_version()` exists in every crate here); alias of
+/// [`TESTED_MUSE_VERSION`]. Kept in lockstep with the README by CI.
+pub fn tested_cli_version() -> &'static str {
+    TESTED_MUSE_VERSION
+}
+
+/// The full build string of the tested release; alias of
+/// [`TESTED_MUSE_BUILD`].
+pub fn tested_cli_build() -> &'static str {
+    TESTED_MUSE_BUILD
+}

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.19] - 2026-08-19
+
+### Added
+
+- **`version::tested_cli_version()`** — the tested-against opencode
+  release, machine-readable from the published artifact. The live
+  version watchdog now asserts the server against this pin instead of
+  the crate version, so crate-side patch offsets no longer trip it.
+
 ## [1.18.18] - 2026-08-14
 
 ### Changed

--- a/opencode-codes/Cargo.toml
+++ b/opencode-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opencode-codes"
-version = "1.18.18"
+version = "1.18.19"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/opencode-codes/src/lib.rs
+++ b/opencode-codes/src/lib.rs
@@ -76,6 +76,7 @@
 
 pub mod error;
 pub mod protocol_generated;
+pub mod version;
 
 pub use error::{Error, Result};
 

--- a/opencode-codes/src/version.rs
+++ b/opencode-codes/src/version.rs
@@ -1,0 +1,8 @@
+//! Tested-against pin, machine-readable.
+
+/// The opencode release this crate's live suite last passed against —
+/// also asserted at runtime by the integration tests against the server's
+/// reported version. Kept in lockstep with the README by CI.
+pub fn tested_cli_version() -> &'static str {
+    "1.18.18"
+}

--- a/opencode-codes/tests/integration_tests.rs
+++ b/opencode-codes/tests/integration_tests.rs
@@ -99,8 +99,8 @@ async fn create_list_abort_loop() {
     );
     assert_eq!(
         session.version,
-        env!("CARGO_PKG_VERSION"),
-        "server version drifted from the crate pin"
+        opencode_codes::version::tested_cli_version(),
+        "server version drifted from the tested pin"
     );
 
     // A brand-new session has no messages yet.


### PR DESCRIPTION
Matt's ask: the published crate version should **link to the tested CLI version**. It did — but only via README prose, and the one programmatic pin that existed had silently drifted: codex's private `TESTED_VERSION` const still said **0.146.0** while its README said 0.147.0, so the runtime newer-version warning was keyed off a stale baseline.

Now the link is machine-readable from every published artifact and cannot drift:

- **`version::tested_cli_version()`** in all four crates (muse gains it as a uniform alias over its existing `TESTED_MUSE_VERSION`/`TESTED_MUSE_BUILD` pins — nearly clobbered those before noticing muse had solved this first)
- **CI lockstep clauses**: the consistency check now compares each const against its README `Tested against:` line — the codex-style silent drift fails the build from here on
- **opencode's live watchdog** asserts the server against `tested_cli_version()` instead of `CARGO_PKG_VERSION` — the correct semantic under version-means-tested, and crate-side patch offsets no longer trip it
- Trains: claude → **2.1.234**, opencode → **1.18.19** (published numbers were taken; offsets noted in README bullets); codex/muse absorb into unpublished 0.147.0/0.1.8

All suites green, workspace clippy clean, consistency clauses verified locally.