### PR TITLE
codex-codes 0.147.1: ExecEvent wire shape matches exec JSONL and its consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.0"
+version = "0.147.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.0`, tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.147.1` (tested CLI + 1 crate-side patch), tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.1.8` (tested CLI + 8 crate-side patches), tested against Muse Code `0.1.0` (build `0.1.0-R708.1`; Meta has shipped no newer CLI).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.1] - 2026-08-19
+
+### Changed
+
+- **`ExecEvent` wire shape v2** (bend-before-freeze with the filing
+  consumer, done hours after 0.147.0 published and before anything
+  adopted it): lifecycle events now serialize FLAT like real exec JSONL
+  (`thread.started` carries `thread_id`; `turn.completed` lifts
+  `turn_id`/`status`/`duration_ms`, full typed payloads still ride
+  along), and everything unmapped serializes as the proxy-forwarded
+  shape `{"type": "<slash method>", "params": …}` instead of a `raw`
+  tag — so passthrough renderers keyed on slash-form types work
+  unchanged and the load-bearing dot/slash split is preserved. The
+  invented `item.agentMessage.delta` / `thread.tokenUsage` dotted tags
+  are gone; those notifications ride the slash passthrough as on the
+  real proxy wire. Round-trip Deserialize handles the dynamic Raw tag.
+
 ## [0.147.0] - 2026-08-19
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.0"
+version = "0.147.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/events.rs
+++ b/codex-codes/src/events.rs
@@ -3,77 +3,77 @@
 //! Downstream renderers (agent-portal's codex-session-lib was the filing
 //! consumer) want a stable, serializable event stream in the shape of the
 //! CLI's `codex exec` JSONL — without hand-rolling a synthetic struct per
-//! notification and re-serializing typed items back into JSON. This module
-//! is that adapter: [`ExecEvent::from_notification`] maps the lifecycle
-//! notifications renderers actually draw onto tagged, serde-stable events,
-//! and passes everything else through as [`ExecEvent::Raw`] with its wire
-//! method and params preserved — unknown future notifications degrade to
-//! raw, never disappear.
+//! notification and re-serializing typed items back into JSON.
+//!
+//! The serialized contract (settled with that consumer before adoption,
+//! and matching real exec JSONL, which is FLAT — `thread.started` carries
+//! `thread_id` top-level, `turn.completed` lifts `turn_id`/`status`/
+//! `duration_ms`):
+//!
+//! - **Lifecycle events use dotted exec tags** (`thread.started`,
+//!   `turn.completed`, `item.started`, …) with snake_case event-level
+//!   fields lifted flat, plus the full typed payload riding along
+//!   (`thread:`/`turn:`) for consumers that want more than the flat keys.
+//! - **Everything else serializes as a forwarded notification**:
+//!   `{"type": "<slash-form method>", "params": <inner payload>}` — e.g.
+//!   `turn/diff/updated`, `item/agentMessage/delta`. The dot/slash split is
+//!   load-bearing: dots are thread events, slashes are verbatim app-server
+//!   notifications.
+//! - **Item payloads embed the typed [`ThreadItem`]**, which serializes in
+//!   the app-server's camelCase item shape (`"commandExecution"`, not
+//!   exec's `"command_execution"`).
+//! - **Turn errors arrive as `turn.failed`**, never as a bare `error` tag —
+//!   that tag stays free for host-level errors (the portal claims it).
+//! - **`item.updated` is absent by construction**: the exec format has the
+//!   tag, but app-server 0.147 has no item-update notification to map from
+//!   (`item/fileChange/patchUpdated` is the closest, and rides the slash
+//!   passthrough). A consumer synthesizing `item.updated` locally keeps
+//!   doing so.
 
 use crate::messages::Notification;
-use crate::protocol_generated::types::{Thread, ThreadItem, ThreadTokenUsage, Turn, TurnError};
-use serde::{Deserialize, Serialize};
+use crate::protocol_generated::types::{Thread, ThreadItem, Turn, TurnError, TurnStatus};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
-/// One renderable event, tagged in `codex exec` JSONL style.
-///
-/// Typed payloads (`ThreadItem`, `Turn`, …) are embedded directly — they
-/// already serialize to their wire shapes, so consumers get stable JSON
-/// without a re-serialization layer.
+/// One renderable event. See the module docs for the serialized contract.
 // Thread/ThreadItem payloads dwarf Raw. Like the Notification enum itself,
 // this is a transient per-frame classification consumers unpack promptly;
 // boxing would tax every construction/match site for no retained-memory win.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ExecEvent {
-    #[serde(rename = "thread.started")]
-    ThreadStarted { thread: Thread },
-    #[serde(rename = "turn.started")]
+    /// `thread.started` — `thread_id` flat (exec shape), full typed thread
+    /// riding along.
+    ThreadStarted { thread_id: String, thread: Thread },
+    /// `turn.started`
     TurnStarted { thread_id: String, turn: Turn },
-    #[serde(rename = "turn.completed")]
+    /// `turn.completed` — `turn_id`/`status`/`duration_ms` lifted flat
+    /// (exec shape); the full typed turn rides along.
     TurnCompleted { thread_id: String, turn: Turn },
-    /// A turn-scoped error (`error` notification) — the closest app-server
-    /// analog to exec's `turn.failed`.
-    #[serde(rename = "turn.failed")]
+    /// `turn.failed` — a turn-scoped `error` notification.
     TurnFailed {
         thread_id: String,
         turn_id: String,
         error: TurnError,
     },
-    #[serde(rename = "item.started")]
+    /// `item.started`
     ItemStarted {
         thread_id: String,
         started_at_ms: i64,
         item: ThreadItem,
     },
-    #[serde(rename = "item.completed")]
+    /// `item.completed`
     ItemCompleted {
         thread_id: String,
         completed_at_ms: i64,
         item: ThreadItem,
     },
-    /// Streamed agent-message text for the active item.
-    #[serde(rename = "item.agentMessage.delta")]
-    AgentMessageDelta {
-        thread_id: String,
-        item_id: String,
-        delta: String,
-    },
-    /// Per-turn token accounting (`thread/tokenUsage/updated`).
-    #[serde(rename = "thread.tokenUsage")]
-    TokenUsage {
-        thread_id: String,
-        turn_id: String,
-        token_usage: ThreadTokenUsage,
-    },
-    /// Any notification without a first-class mapping above — including
-    /// methods newer than these bindings. The wire method and params are
-    /// preserved verbatim so nothing is droppable-by-default.
-    #[serde(rename = "raw")]
+    /// Any other notification, serialized as the proxy-forwarded shape
+    /// `{"type": "<method>", "params": …}` — slash tags preserved, params
+    /// verbatim. Unknown future methods land here, never disappear.
     Raw {
         method: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         params: Option<Value>,
     },
 }
@@ -81,10 +81,13 @@ pub enum ExecEvent {
 impl ExecEvent {
     /// Map one notification onto its exec-style event. Never fails and
     /// never drops: lifecycle notifications get first-class variants,
-    /// everything else round-trips through [`ExecEvent::Raw`].
+    /// everything else rides [`ExecEvent::Raw`] under its wire method.
     pub fn from_notification(notification: Notification) -> ExecEvent {
         match notification {
-            Notification::ThreadStarted(n) => ExecEvent::ThreadStarted { thread: n.thread },
+            Notification::ThreadStarted(n) => ExecEvent::ThreadStarted {
+                thread_id: n.thread.id.clone(),
+                thread: n.thread,
+            },
             Notification::TurnStarted(n) => ExecEvent::TurnStarted {
                 thread_id: n.thread_id,
                 turn: n.turn,
@@ -108,16 +111,6 @@ impl ExecEvent {
                 completed_at_ms: n.completed_at_ms,
                 item: n.item,
             },
-            Notification::AgentMessageDelta(n) => ExecEvent::AgentMessageDelta {
-                thread_id: n.thread_id,
-                item_id: n.item_id,
-                delta: n.delta,
-            },
-            Notification::ThreadTokenUsageUpdated(n) => ExecEvent::TokenUsage {
-                thread_id: n.thread_id,
-                turn_id: n.turn_id,
-                token_usage: n.token_usage,
-            },
             other => {
                 let method = other.method().to_string();
                 match other.into_envelope() {
@@ -132,16 +125,233 @@ impl ExecEvent {
             }
         }
     }
+
+    /// The serialized `type` tag this event carries.
+    pub fn tag(&self) -> &str {
+        match self {
+            ExecEvent::ThreadStarted { .. } => "thread.started",
+            ExecEvent::TurnStarted { .. } => "turn.started",
+            ExecEvent::TurnCompleted { .. } => "turn.completed",
+            ExecEvent::TurnFailed { .. } => "turn.failed",
+            ExecEvent::ItemStarted { .. } => "item.started",
+            ExecEvent::ItemCompleted { .. } => "item.completed",
+            ExecEvent::Raw { method, .. } => method,
+        }
+    }
+}
+
+/// Wire form of the dotted lifecycle events (everything except `Raw`,
+/// whose tag is dynamic and therefore hand-serialized).
+#[allow(clippy::large_enum_variant)]
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum LifecycleWire {
+    #[serde(rename = "thread.started")]
+    ThreadStarted { thread_id: String, thread: Thread },
+    #[serde(rename = "turn.started")]
+    TurnStarted { thread_id: String, turn: Turn },
+    #[serde(rename = "turn.completed")]
+    TurnCompleted {
+        thread_id: String,
+        turn_id: String,
+        status: TurnStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<i64>,
+        turn: Turn,
+    },
+    #[serde(rename = "turn.failed")]
+    TurnFailed {
+        thread_id: String,
+        turn_id: String,
+        error: TurnError,
+    },
+    #[serde(rename = "item.started")]
+    ItemStarted {
+        thread_id: String,
+        started_at_ms: i64,
+        item: ThreadItem,
+    },
+    #[serde(rename = "item.completed")]
+    ItemCompleted {
+        thread_id: String,
+        completed_at_ms: i64,
+        item: ThreadItem,
+    },
+}
+
+impl Serialize for ExecEvent {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ExecEvent::Raw { method, params } => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", method)?;
+                if let Some(params) = params {
+                    map.serialize_entry("params", params)?;
+                }
+                map.end()
+            }
+            ExecEvent::TurnCompleted { thread_id, turn } => LifecycleWire::TurnCompleted {
+                thread_id: thread_id.clone(),
+                turn_id: turn.id.clone(),
+                status: turn.status.clone(),
+                duration_ms: turn.duration_ms,
+                turn: turn.clone(),
+            }
+            .serialize(serializer),
+            ExecEvent::ThreadStarted { thread_id, thread } => LifecycleWire::ThreadStarted {
+                thread_id: thread_id.clone(),
+                thread: thread.clone(),
+            }
+            .serialize(serializer),
+            ExecEvent::TurnStarted { thread_id, turn } => LifecycleWire::TurnStarted {
+                thread_id: thread_id.clone(),
+                turn: turn.clone(),
+            }
+            .serialize(serializer),
+            ExecEvent::TurnFailed {
+                thread_id,
+                turn_id,
+                error,
+            } => LifecycleWire::TurnFailed {
+                thread_id: thread_id.clone(),
+                turn_id: turn_id.clone(),
+                error: error.clone(),
+            }
+            .serialize(serializer),
+            ExecEvent::ItemStarted {
+                thread_id,
+                started_at_ms,
+                item,
+            } => LifecycleWire::ItemStarted {
+                thread_id: thread_id.clone(),
+                started_at_ms: *started_at_ms,
+                item: item.clone(),
+            }
+            .serialize(serializer),
+            ExecEvent::ItemCompleted {
+                thread_id,
+                completed_at_ms,
+                item,
+            } => LifecycleWire::ItemCompleted {
+                thread_id: thread_id.clone(),
+                completed_at_ms: *completed_at_ms,
+                item: item.clone(),
+            }
+            .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExecEvent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let tag = value
+            .get("type")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| D::Error::missing_field("type"))?;
+        match tag {
+            "thread.started" | "turn.started" | "turn.completed" | "turn.failed"
+            | "item.started" | "item.completed" => {
+                let wire: LifecycleWire =
+                    serde_json::from_value(value).map_err(D::Error::custom)?;
+                Ok(match wire {
+                    LifecycleWire::ThreadStarted { thread_id, thread } => {
+                        ExecEvent::ThreadStarted { thread_id, thread }
+                    }
+                    LifecycleWire::TurnStarted { thread_id, turn } => {
+                        ExecEvent::TurnStarted { thread_id, turn }
+                    }
+                    LifecycleWire::TurnCompleted {
+                        thread_id, turn, ..
+                    } => ExecEvent::TurnCompleted { thread_id, turn },
+                    LifecycleWire::TurnFailed {
+                        thread_id,
+                        turn_id,
+                        error,
+                    } => ExecEvent::TurnFailed {
+                        thread_id,
+                        turn_id,
+                        error,
+                    },
+                    LifecycleWire::ItemStarted {
+                        thread_id,
+                        started_at_ms,
+                        item,
+                    } => ExecEvent::ItemStarted {
+                        thread_id,
+                        started_at_ms,
+                        item,
+                    },
+                    LifecycleWire::ItemCompleted {
+                        thread_id,
+                        completed_at_ms,
+                        item,
+                    } => ExecEvent::ItemCompleted {
+                        thread_id,
+                        completed_at_ms,
+                        item,
+                    },
+                })
+            }
+            method => Ok(ExecEvent::Raw {
+                method: method.to_string(),
+                params: value.get("params").cloned(),
+            }),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Lifecycle notifications map to exec-tagged events whose JSON shape
-    /// is stable (`type` tag in exec JSONL style).
+    /// The consumer contract, pinned: `thread.started` carries `thread_id`
+    /// flat; `turn.completed` lifts `turn_id`/`status`/`duration_ms` —
+    /// the fields renderers (and real exec JSONL) put top-level.
     #[test]
-    fn item_completed_maps_to_exec_tagged_json() {
+    fn lifecycle_events_carry_the_consumer_fields_flat() {
+        let n = Notification::from_envelope(
+            "turn/completed",
+            Some(serde_json::json!({
+                "threadId": "t-1",
+                "turn": {"id": "turn-9", "status": "completed", "durationMs": 42,
+                          "items": [], "threadId": "t-1"}
+            })),
+        )
+        .expect("typed");
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+        assert_eq!(v["type"], "turn.completed");
+        assert_eq!(v["turn_id"], "turn-9");
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["duration_ms"], 42);
+        assert_eq!(v["thread_id"], "t-1");
+    }
+
+    /// `thread.started` exposes the flat `thread_id` consumers key on.
+    #[test]
+    fn thread_started_is_flat() {
+        let n = Notification::from_envelope(
+            "thread/started",
+            Some(serde_json::json!({
+                "thread": {"id": "t-7", "status": {"type": "idle"}, "items": [],
+                            "cliVersion": "0.147.0", "createdAt": 1, "updatedAt": 1,
+                            "cwd": "/", "ephemeral": false, "originator": "test",
+                            "preset": null, "modelSlug": "m", "turns": []}
+            })),
+        )
+        .expect("typed");
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+        assert_eq!(v["type"], "thread.started");
+        assert_eq!(v["thread_id"], "t-7");
+        assert_eq!(v["thread"]["id"], "t-7");
+    }
+
+    /// Item payloads serialize in the app-server camelCase item shape —
+    /// the settled answer to the `commandExecution` vs `command_execution`
+    /// double-match downstreams carry today.
+    #[test]
+    fn item_events_use_dotted_tags_and_camel_item_types() {
         let n = Notification::from_envelope(
             "item/completed",
             Some(serde_json::json!({
@@ -150,48 +360,84 @@ mod tests {
                 "item": {"type": "agentMessage", "id": "i-1", "text": "hi"}
             })),
         )
-        .expect("typed notification");
-        let event = ExecEvent::from_notification(n);
-        let v = serde_json::to_value(&event).expect("serialize");
+        .expect("typed");
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
         assert_eq!(v["type"], "item.completed");
-        assert_eq!(v["thread_id"], "t-1");
         assert_eq!(v["item"]["type"], "agentMessage");
-        assert_eq!(v["item"]["text"], "hi");
     }
 
-    /// Unknown methods pass through with method + params preserved — a
-    /// newer CLI's notification degrades to raw, never disappears.
+    /// Non-lifecycle notifications serialize as the proxy-forwarded shape:
+    /// slash-form method as the tag, params verbatim — the dot/slash split
+    /// consumers key on is preserved exactly, so passthrough renderers
+    /// (`turn/diff/updated` etc.) work unchanged.
     #[test]
-    fn unknown_notification_passes_through_raw() {
-        let n = Notification::from_envelope("somefuture/thing", Some(serde_json::json!({"x": 1})))
-            .expect("unknown routes to Unknown without error");
-        let event = ExecEvent::from_notification(n);
-        match &event {
-            ExecEvent::Raw { method, params } => {
-                assert_eq!(method, "somefuture/thing");
-                assert_eq!(params.as_ref().unwrap()["x"], 1);
-            }
-            other => panic!("expected Raw, got {other:?}"),
-        }
-        let v = serde_json::to_value(&event).expect("serialize");
-        assert_eq!(v["type"], "raw");
-    }
-
-    /// A typed-but-unmapped notification (no first-class exec variant) also
-    /// rides Raw, keeping its wire method — nothing is droppable-by-default.
-    #[test]
-    fn typed_but_unmapped_notification_rides_raw_with_its_method() {
+    fn forwarded_notifications_keep_slash_tags_and_params() {
+        // Typed methods re-serialize through their param structs, so use a
+        // real field and assert it survives under `params`.
         let n = Notification::from_envelope(
-            "thread/reverted",
-            Some(serde_json::json!({"threadId": "t-9"})),
+            "turn/diff/updated",
+            Some(serde_json::json!({"threadId": "t-1", "turnId": "u-1", "diff": "+x"})),
+        )
+        .expect("routes");
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+        assert_eq!(
+            v["type"], "turn/diff/updated",
+            "slash tag survives verbatim"
+        );
+        assert_eq!(
+            v["params"]["diff"], "+x",
+            "typed params ride under 'params'"
+        );
+
+        // Unknown methods carry their params verbatim.
+        let n = Notification::from_envelope("somefuture/thing", Some(serde_json::json!({"x": 1})))
+            .expect("routes to Unknown");
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+        assert_eq!(v["type"], "somefuture/thing");
+        assert_eq!(v["params"]["x"], 1);
+
+        // And the other three passthrough renderers' tags stay slash-form.
+        for method in [
+            "item/fileChange/patchUpdated",
+            "turn/plan/updated",
+            "item/plan/delta",
+            "item/agentMessage/delta",
+        ] {
+            let n =
+                Notification::from_envelope(method, Some(serde_json::json!({}))).expect("routes");
+            let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+            assert_eq!(v["type"], method, "slash tag survives verbatim");
+        }
+    }
+
+    /// A turn error arrives as `turn.failed` with the typed error under
+    /// `error` — the bare `error` tag is never emitted (it belongs to the
+    /// host layer; the portal claims it for its own errors).
+    #[test]
+    fn turn_errors_are_turn_failed_never_bare_error() {
+        let n = Notification::from_envelope(
+            "error",
+            Some(serde_json::json!({
+                "threadId": "t-1", "turnId": "turn-1",
+                "error": {"message": "boom"}
+            })),
         )
         .expect("typed");
-        match ExecEvent::from_notification(n) {
-            ExecEvent::Raw { method, params } => {
-                assert_eq!(method, "thread/reverted");
-                assert_eq!(params.unwrap()["threadId"], "t-9");
-            }
-            other => panic!("expected Raw, got {other:?}"),
-        }
+        let v = serde_json::to_value(ExecEvent::from_notification(n)).expect("serialize");
+        assert_eq!(v["type"], "turn.failed");
+        assert_eq!(v["error"]["message"], "boom");
+    }
+
+    /// Round trip: serialize → deserialize lands back in the same variant,
+    /// including dynamic-tag Raw.
+    #[test]
+    fn events_round_trip_including_dynamic_raw_tags() {
+        let raw = ExecEvent::Raw {
+            method: "somefuture/thing".into(),
+            params: Some(serde_json::json!({"x": 1})),
+        };
+        let v = serde_json::to_value(&raw).expect("serialize");
+        let back: ExecEvent = serde_json::from_value(v).expect("deserialize");
+        assert_eq!(back, raw);
     }
 }


### PR DESCRIPTION
The bend-before-freeze window, used: 0.147.0's `ExecEvent` published hours ago and nothing has adopted it, so its serialization can still change. Comparing it field-by-field against the filing consumer's deployed contract (agent-portal's `codex_renderer/events.rs`) AND real exec JSONL showed v1 was wrong on both counts **in the same direction**:

- real exec JSONL is **flat** (`thread.started{thread_id}`, `turn.completed{turn_id, status, duration_ms}`) — v1 nested typed structs
- the portal proxy forwards non-lifecycle notifications as `{type: "<slash method>", params}` — v1 wrapped them in a `raw` tag, which would have sent four working renderers dark

v2 fixes both: flat lifted fields (typed payloads still ride along), dynamic-tag Raw serialization via hand-written serde (round-trip tested), invented dotted tags removed. The dot/slash split — thread events vs forwarded notifications — is preserved exactly and documented as load-bearing. `turn.failed`-never-bare-`error` stands (the portal claims the bare tag for host errors, sequenced with their #1703).

**Net effect downstream**: the portal's adoption cost drops from "rewrite four passthrough paths + absorb field moves" to "delete the synthetic layer; only the locally-synthesized `item.updated` shim remains" (app-server 0.147 has no item-update notification to map — documented).

0.147.0 → 0.147.1 (crate-side patch; 0.147.0 is on crates.io and versions are immutable). Publish-ready on the word.