### PR TITLE
codex-codes 0.147.2: resnapshot vs openai/codex@main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.1"
+version = "0.147.2"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.1` (tested CLI + 1 crate-side patch), tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.147.2` (tested CLI + 2 crate-side patches), tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.2] - 2026-08-21
+
+### Added
+
+- Resnapshot vs `openai/codex@main` (fixes #328): typed
+  `mcpServer/event/stream/notification` (an MCP server's own
+  notification stream relayed to subscribers —
+  `McpServerEventStreamNotification` wrapping
+  `McpServerEventNotification`), `InAppBrowserRequirements` with the
+  matching `ConfigRequirements.inAppBrowser` +
+  `additionalDeveloperInstructions` fields. `ResponseItem`'s
+  function-call-output loosening is snapshot-only (that type is
+  upstream-internal, never modeled here). `ExecEvent` needs no change:
+  the new notification rides the slash passthrough by construction.
+
 ## [0.147.1] - 2026-08-19
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.1"
+version = "0.147.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -38,8 +38,8 @@ use crate::protocol::{
     GuardianWarningNotification, HookCompletedNotification, HookStartedNotification,
     ItemCompletedNotification, ItemGuardianApprovalReviewCompletedNotification,
     ItemGuardianApprovalReviewStartedNotification, ItemStartedNotification,
-    McpServerOauthLoginCompletedNotification, McpServerStatusUpdatedNotification,
-    McpToolCallProgressNotification, ModelReroutedNotification,
+    McpServerEventStreamNotification, McpServerOauthLoginCompletedNotification,
+    McpServerStatusUpdatedNotification, McpToolCallProgressNotification, ModelReroutedNotification,
     ModelSafetyBufferingUpdatedNotification, ModelVerificationNotification, PlanDeltaNotification,
     ProcessExitedNotification, ProcessOutputDeltaNotification, ProjectChangedNotification,
     ReasoningSummaryPartAddedNotification, ReasoningSummaryTextDeltaNotification,
@@ -219,6 +219,8 @@ pub enum Notification {
     ThreadQueueChanged(ThreadQueueChangedNotification),
     /// `thread/reverted` (0.147)
     ThreadReverted(ThreadRevertedNotification),
+    /// `mcpServer/event/stream/notification` (0.148 upstream)
+    McpServerEventStream(McpServerEventStreamNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -238,6 +240,7 @@ impl Notification {
             Self::ThreadProjectUpdated(_) => methods::THREAD_PROJECT_UPDATED,
             Self::ThreadQueueChanged(_) => methods::THREAD_QUEUE_CHANGED,
             Self::ThreadReverted(_) => methods::THREAD_REVERTED,
+            Self::McpServerEventStream(_) => methods::MCP_SERVER_EVENT_STREAM,
             Self::ThreadStatusChanged(_) => methods::THREAD_STATUS_CHANGED,
             Self::ThreadTokenUsageUpdated(_) => methods::THREAD_TOKEN_USAGE_UPDATED,
             Self::TurnStarted(_) => methods::TURN_STARTED,
@@ -407,6 +410,9 @@ impl Notification {
             }
             methods::THREAD_REVERTED => {
                 serde_json::from_value(params_value).map(Self::ThreadReverted)
+            }
+            methods::MCP_SERVER_EVENT_STREAM => {
+                serde_json::from_value(params_value).map(Self::McpServerEventStream)
             }
             methods::THREAD_STATUS_CHANGED => {
                 serde_json::from_value(params_value).map(Self::ThreadStatusChanged)
@@ -621,6 +627,7 @@ impl Notification {
             Self::ThreadProjectUpdated(v) => pack(methods::THREAD_PROJECT_UPDATED, v),
             Self::ThreadQueueChanged(v) => pack(methods::THREAD_QUEUE_CHANGED, v),
             Self::ThreadReverted(v) => pack(methods::THREAD_REVERTED, v),
+            Self::McpServerEventStream(v) => pack(methods::MCP_SERVER_EVENT_STREAM, v),
             Self::ThreadStatusChanged(v) => pack(methods::THREAD_STATUS_CHANGED, v),
             Self::ThreadTokenUsageUpdated(v) => pack(methods::THREAD_TOKEN_USAGE_UPDATED, v),
             Self::TurnStarted(v) => pack(methods::TURN_STARTED, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -133,6 +133,7 @@ pub mod methods {
     pub const THREAD_PROJECT_UPDATED: &str = "thread/project/updated";
     pub const THREAD_QUEUE_CHANGED: &str = "thread/queue/changed";
     pub const THREAD_REVERTED: &str = "thread/reverted";
+    pub const MCP_SERVER_EVENT_STREAM: &str = "mcpServer/event/stream/notification";
     pub const THREAD_STATUS_CHANGED: &str = "thread/status/changed";
     pub const THREAD_TOKEN_USAGE_UPDATED: &str = "thread/tokenUsage/updated";
     pub const TURN_STARTED: &str = "turn/started";

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -1335,6 +1335,18 @@ pub struct ConfigReadResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ConfigRequirements {
     #[serde(
+        rename = "additionalDeveloperInstructions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_developer_instructions: Option<String>,
+    #[serde(
+        rename = "inAppBrowser",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub in_app_browser: Option<InAppBrowserRequirements>,
+    #[serde(
         rename = "chatgptBaseUrl",
         default,
         skip_serializing_if = "Option::is_none"
@@ -5929,6 +5941,36 @@ pub struct ThreadQueueChangedNotification {
 pub struct ThreadRevertedNotification {
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+}
+
+/// In-app browser requirements (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct InAppBrowserRequirements {
+    #[serde(
+        rename = "allowExternalBrowserSettingsImport",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_external_browser_settings_import: Option<bool>,
+}
+
+/// One MCP-server-originated notification, relayed verbatim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpServerEventNotification {
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+/// `mcpServer/event/stream/notification` — an MCP server's own
+/// notification stream, forwarded to subscribers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpServerEventStreamNotification {
+    pub notification: McpServerEventNotification,
+    #[serde(rename = "subscriptionId", default)]
+    pub subscription_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -618,6 +618,7 @@ async fn test_typed_message_audit_strict() {
                     Notification::ThreadProjectUpdated(_) => "ThreadProjectUpdated",
                     Notification::ThreadQueueChanged(_) => "ThreadQueueChanged",
                     Notification::ThreadReverted(_) => "ThreadReverted",
+                    Notification::McpServerEventStream(_) => "McpServerEventStream",
                     Notification::ThreadRealtimeClosed(_) => "ThreadRealtimeClosed",
                     Notification::ThreadRealtimeError(_) => "ThreadRealtimeError",
                     Notification::ThreadRealtimeItemAdded(_) => "ThreadRealtimeItemAdded",

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -5206,6 +5206,26 @@
           "properties": {
             "method": {
               "enum": [
+                "mcpServer/event/stream/notification"
+              ],
+              "title": "McpServer/event/stream/notificationNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/McpServerEventStreamNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "McpServer/event/stream/notificationNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "account/updated"
               ],
               "title": "Account/updatedNotificationMethod",
@@ -8908,6 +8928,12 @@
       },
       "ConfigRequirements": {
         "properties": {
+          "additionalDeveloperInstructions": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "allowAppshots": {
             "type": [
               "boolean",
@@ -9058,6 +9084,16 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/v2/FeedbackRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "inAppBrowser": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/InAppBrowserRequirements"
               },
               {
                 "type": "null"
@@ -12419,6 +12455,17 @@
           }
         ]
       },
+      "InAppBrowserRequirements": {
+        "properties": {
+          "allowExternalBrowserSettingsImport": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "InputModality": {
         "description": "Canonical user-input modality tags advertised by a model.",
         "oneOf": [
@@ -13355,6 +13402,36 @@
           "contents"
         ],
         "title": "McpResourceReadResponse",
+        "type": "object"
+      },
+      "McpServerEventNotification": {
+        "properties": {
+          "method": {
+            "type": "string"
+          },
+          "params": true
+        },
+        "required": [
+          "method",
+          "params"
+        ],
+        "type": "object"
+      },
+      "McpServerEventStreamNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "notification": {
+            "$ref": "#/definitions/v2/McpServerEventNotification"
+          },
+          "subscriptionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "notification",
+          "subscriptionId"
+        ],
+        "title": "McpServerEventStreamNotification",
         "type": "object"
       },
       "McpServerInfo": {
@@ -17295,7 +17372,10 @@
           {
             "properties": {
               "call_id": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "id": {
                 "type": [
@@ -17313,6 +17393,18 @@
                   }
                 ]
               },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "namespace": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "output": {
                 "$ref": "#/definitions/v2/FunctionCallOutputBody"
               },
@@ -17325,7 +17417,6 @@
               }
             },
             "required": [
-              "call_id",
               "output",
               "type"
             ],
@@ -21086,6 +21177,27 @@
               "type"
             ],
             "title": "WebrtcThreadRealtimeStartTransport",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "callId": {
+                "description": "Identifier of a realtime call already created and negotiated by the client.",
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "existingCall"
+                ],
+                "title": "ExistingCallThreadRealtimeStartTransportType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "callId",
+              "type"
+            ],
+            "title": "ExistingCallThreadRealtimeStartTransport",
             "type": "object"
           }
         ]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -4966,6 +4966,12 @@
     },
     "ConfigRequirements": {
       "properties": {
+        "additionalDeveloperInstructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "allowAppshots": {
           "type": [
             "boolean",
@@ -5116,6 +5122,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/FeedbackRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inAppBrowser": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InAppBrowserRequirements"
             },
             {
               "type": "null"
@@ -8588,6 +8604,17 @@
         }
       ]
     },
+    "InAppBrowserRequirements": {
+      "properties": {
+        "allowExternalBrowserSettingsImport": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "InitializeCapabilities": {
       "description": "Client-declared capabilities negotiated during initialize.",
       "properties": {
@@ -9585,6 +9612,36 @@
         "contents"
       ],
       "title": "McpResourceReadResponse",
+      "type": "object"
+    },
+    "McpServerEventNotification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": true
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "McpServerEventStreamNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "notification": {
+          "$ref": "#/definitions/McpServerEventNotification"
+        },
+        "subscriptionId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "notification",
+        "subscriptionId"
+      ],
+      "title": "McpServerEventStreamNotification",
       "type": "object"
     },
     "McpServerInfo": {
@@ -13525,7 +13582,10 @@
         {
           "properties": {
             "call_id": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": [
@@ -13543,6 +13603,18 @@
                 }
               ]
             },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "namespace": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "output": {
               "$ref": "#/definitions/FunctionCallOutputBody"
             },
@@ -13555,7 +13627,6 @@
             }
           },
           "required": [
-            "call_id",
             "output",
             "type"
           ],
@@ -15393,6 +15464,26 @@
             "params"
           ],
           "title": "McpServer/startupStatus/updatedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "mcpServer/event/stream/notification"
+              ],
+              "title": "McpServer/event/stream/notificationNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/McpServerEventStreamNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "McpServer/event/stream/notificationNotification",
           "type": "object"
         },
         {
@@ -18838,6 +18929,27 @@
             "type"
           ],
           "title": "WebrtcThreadRealtimeStartTransport",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "callId": {
+              "description": "Identifier of a realtime call already created and negotiated by the client.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "existingCall"
+              ],
+              "title": "ExistingCallThreadRealtimeStartTransportType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "callId",
+            "type"
+          ],
+          "title": "ExistingCallThreadRealtimeStartTransport",
           "type": "object"
         }
       ]


### PR DESCRIPTION
Fixes #328 — last night's drift report, resolved in the established pattern (snapshots byte-identical, types hand-mirrored, no codegen rerun). Dedicated drift-only PR as requested.

**Absorbed:**
- `mcpServer/event/stream/notification` — an MCP server's own notification stream relayed to subscribers; typed end-to-end (`McpServerEventStreamNotification` wrapping `McpServerEventNotification`, method constant, all four `Notification` dispatch sites, live-audit arm)
- `InAppBrowserRequirements` + `ConfigRequirements.inAppBrowser`/`additionalDeveloperInstructions`
- `ResponseItem` function-call-output loosening: **snapshot-only** — upstream-internal type, never modeled crate-side
- `ExecEvent`: no change needed — the new notification rides the slash passthrough by construction (the v2 contract paying off on its first drift)

**Verification:** drift script reports both snapshots byte-identical; all tests green; live wirecheck codex tier green. 0.147.1 → 0.147.2 (crate-side patch; tested pin stays 0.147.0).