### PR TITLE
codex-codes 0.147.3: resnapshot vs openai/codex@main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.2"
+version = "0.147.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.2` (tested CLI + 2 crate-side patches), tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.147.3` (tested CLI + 3 crate-side patches), tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.3] - 2026-08-22
+
+### Added
+
+- Resnapshot vs `openai/codex@main` (fixes #330): the browser-use /
+  computer-use policy surface — `AllowDenyRequirement`,
+  per-origin `BrowserUseOriginPolicy{,Config}` with approval lifetimes,
+  `ComputerUse{Macos,Windows}{Requirements,Config}` (bundle-id / AUMID /
+  signed-exe allowlists), the matching field additions on
+  `BrowserUseRequirements` / `ComputerUseRequirements` / `Config` /
+  `ConfigRequirements.allowBrowserAndComputerUse`, and
+  `McpServerStatus.runtimeStatus` (new typed
+  `McpServerConnectionStatus`). Note the wire's own casing split:
+  requirements types are camelCase, config types snake_case — mirrored
+  exactly.
+
 ## [0.147.2] - 2026-08-21
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.2"
+version = "0.147.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -635,6 +635,26 @@ pub struct AutoReviewRequirements {
 #[serde(rename_all = "camelCase")]
 pub struct BrowserUseRequirements {
     #[serde(
+        rename = "allowGlobalPersistentApproval",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_global_persistent_approval: Option<bool>,
+    #[serde(
+        rename = "allowHistoryAccess",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_history_access: Option<bool>,
+    #[serde(
+        rename = "defaultOriginPolicy",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_origin_policy: Option<BrowserUseOriginPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origins: Option<std::collections::HashMap<String, BrowserUseOriginPolicy>>,
+    #[serde(
         rename = "disableAutoReview",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1153,6 +1173,22 @@ pub struct CommandMigration {
 #[serde(rename_all = "camelCase")]
 pub struct ComputerUseRequirements {
     #[serde(
+        rename = "allowPersistentApproval",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_persistent_approval: Option<bool>,
+    #[serde(
+        rename = "defaultAppAccess",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_app_access: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub macos: Option<ComputerUseMacosRequirements>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<ComputerUseWindowsRequirements>,
+    #[serde(
         rename = "allowLockedComputerUse",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1165,6 +1201,10 @@ pub struct ComputerUseRequirements {
 pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub analytics: Option<AnalyticsConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_use: Option<BrowserUseConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub computer_use: Option<ComputerUseConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval_policy: Option<AskForApproval>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1334,6 +1374,12 @@ pub struct ConfigReadResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigRequirements {
+    #[serde(
+        rename = "allowBrowserAndComputerUse",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_browser_and_computer_use: Option<bool>,
     #[serde(
         rename = "additionalDeveloperInstructions",
         default,
@@ -3980,6 +4026,13 @@ pub enum McpServerStartupState {
 pub struct McpServerStatus {
     #[serde(rename = "authStatus")]
     pub auth_status: McpAuthStatus,
+    /// Current thread-runtime connection state; absent when unavailable.
+    #[serde(
+        rename = "runtimeStatus",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub runtime_status: Option<McpServerConnectionStatus>,
     #[serde(default)]
     pub name: String,
     #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
@@ -5971,6 +6024,173 @@ pub struct McpServerEventStreamNotification {
     pub notification: McpServerEventNotification,
     #[serde(rename = "subscriptionId", default)]
     pub subscription_id: String,
+}
+
+/// Allow/deny switch used across the browser-use / computer-use policy
+/// surface (0.148 upstream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AllowDenyRequirement {
+    #[serde(rename = "allow")]
+    Allow,
+    #[serde(rename = "deny")]
+    Deny,
+}
+
+/// How long a granted browser-use access approval lasts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BrowserUseAccessApprovalLifetime {
+    #[serde(rename = "turn")]
+    Turn,
+    #[serde(rename = "thread")]
+    Thread,
+}
+
+/// Current thread-runtime MCP server connection state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum McpServerConnectionStatus {
+    #[serde(rename = "notStarted")]
+    NotStarted,
+    #[serde(rename = "starting")]
+    Starting,
+    #[serde(rename = "connected")]
+    Connected,
+    #[serde(rename = "authenticationRequired")]
+    AuthenticationRequired,
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "cancelled")]
+    Cancelled,
+    #[serde(rename = "disabled")]
+    Disabled,
+}
+
+/// Per-origin browser-use policy (requirements side, camelCase wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserUseOriginPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access: Option<AllowDenyRequirement>,
+    #[serde(
+        rename = "accessApprovalLifetime",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub access_approval_lifetime: Option<BrowserUseAccessApprovalLifetime>,
+    #[serde(
+        rename = "autoReview",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub auto_review: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downloads: Option<AllowDenyRequirement>,
+    #[serde(
+        rename = "fullCdpAccess",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub full_cdp_access: Option<AllowDenyRequirement>,
+    #[serde(
+        rename = "persistentApproval",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub persistent_approval: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uploads: Option<AllowDenyRequirement>,
+}
+
+/// Per-origin browser-use policy (config side, snake_case wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct BrowserUseOriginPolicyConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downloads: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_cdp_access: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uploads: Option<AllowDenyRequirement>,
+}
+
+/// Browser-use configuration (config side, snake_case wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct BrowserUseConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_history_access: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_origin_policy: Option<BrowserUseOriginPolicyConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origins: Option<std::collections::HashMap<String, BrowserUseOriginPolicyConfig>>,
+}
+
+/// Computer-use configuration (config side, snake_case wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ComputerUseConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_app_access: Option<AllowDenyRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub macos: Option<ComputerUseMacosConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<ComputerUseWindowsConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ComputerUseMacosConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_ids: Option<std::collections::HashMap<String, AllowDenyRequirement>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ComputerUseWindowsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aumids: Option<std::collections::HashMap<String, AllowDenyRequirement>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exes: Option<Vec<ComputerUseWindowsExeConfig>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComputerUseWindowsExeConfig {
+    pub access: AllowDenyRequirement,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary_name: Option<String>,
+    #[serde(default)]
+    pub product_name: String,
+    #[serde(default)]
+    pub publisher_name: String,
+}
+
+/// Per-platform computer-use requirements (camelCase wire).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputerUseMacosRequirements {
+    #[serde(rename = "bundleIds", default, skip_serializing_if = "Option::is_none")]
+    pub bundle_ids: Option<std::collections::HashMap<String, AllowDenyRequirement>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputerUseWindowsRequirements {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aumids: Option<std::collections::HashMap<String, AllowDenyRequirement>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exes: Option<Vec<ComputerUseWindowsExeRequirement>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputerUseWindowsExeRequirement {
+    pub access: AllowDenyRequirement,
+    #[serde(
+        rename = "binaryName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub binary_name: Option<String>,
+    #[serde(rename = "productName", default)]
+    pub product_name: String,
+    #[serde(rename = "publisherName", default)]
+    pub publisher_name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -6666,6 +6666,13 @@
       "AgentPath": {
         "type": "string"
       },
+      "AllowDenyRequirement": {
+        "enum": [
+          "allow",
+          "deny"
+        ],
+        "type": "string"
+      },
       "AnalyticsConfig": {
         "additionalProperties": true,
         "properties": {
@@ -7555,11 +7562,195 @@
         },
         "type": "object"
       },
+      "BrowserUseAccessApprovalLifetime": {
+        "enum": [
+          "turn",
+          "thread"
+        ],
+        "type": "string"
+      },
+      "BrowserUseConfig": {
+        "properties": {
+          "allow_history_access": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "default_origin_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/BrowserUseOriginPolicyConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "origins": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/BrowserUseOriginPolicyConfig"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "BrowserUseOriginPolicy": {
+        "properties": {
+          "access": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "accessApprovalLifetime": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/BrowserUseAccessApprovalLifetime"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "autoReview": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "downloads": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "fullCdpAccess": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "persistentApproval": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "uploads": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "BrowserUseOriginPolicyConfig": {
+        "properties": {
+          "access": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "downloads": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "full_cdp_access": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uploads": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
       "BrowserUseRequirements": {
         "properties": {
+          "allowGlobalPersistentApproval": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "allowHistoryAccess": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "defaultOriginPolicy": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/BrowserUseOriginPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "disableAutoReview": {
             "type": [
               "boolean",
+              "null"
+            ]
+          },
+          "origins": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/BrowserUseOriginPolicy"
+            },
+            "type": [
+              "object",
               "null"
             ]
           }
@@ -8365,11 +8556,206 @@
         ],
         "type": "object"
       },
+      "ComputerUseConfig": {
+        "properties": {
+          "default_app_access": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "macos": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseMacosConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "windows": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseWindowsConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ComputerUseMacosConfig": {
+        "properties": {
+          "bundle_ids": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/AllowDenyRequirement"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ComputerUseMacosRequirements": {
+        "properties": {
+          "bundleIds": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/AllowDenyRequirement"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "ComputerUseRequirements": {
         "properties": {
           "allowLockedComputerUse": {
             "type": [
               "boolean",
+              "null"
+            ]
+          },
+          "allowPersistentApproval": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "defaultAppAccess": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AllowDenyRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "macos": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseMacosRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "windows": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseWindowsRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ComputerUseWindowsConfig": {
+        "properties": {
+          "aumids": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/AllowDenyRequirement"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "exes": {
+            "items": {
+              "$ref": "#/definitions/v2/ComputerUseWindowsExeConfig"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ComputerUseWindowsExeConfig": {
+        "properties": {
+          "access": {
+            "$ref": "#/definitions/v2/AllowDenyRequirement"
+          },
+          "binary_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "product_name": {
+            "type": "string"
+          },
+          "publisher_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "access",
+          "product_name",
+          "publisher_name"
+        ],
+        "type": "object"
+      },
+      "ComputerUseWindowsExeRequirement": {
+        "properties": {
+          "access": {
+            "$ref": "#/definitions/v2/AllowDenyRequirement"
+          },
+          "binaryName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "productName": {
+            "type": "string"
+          },
+          "publisherName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "access",
+          "productName",
+          "publisherName"
+        ],
+        "type": "object"
+      },
+      "ComputerUseWindowsRequirements": {
+        "properties": {
+          "aumids": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/AllowDenyRequirement"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "exes": {
+            "items": {
+              "$ref": "#/definitions/v2/ComputerUseWindowsExeRequirement"
+            },
+            "type": [
+              "array",
               "null"
             ]
           }
@@ -8410,10 +8796,30 @@
             ],
             "description": "[UNSTABLE] Optional default for where approval requests are routed for review."
           },
+          "browser_use": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/BrowserUseConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "compact_prompt": {
             "type": [
               "string",
               "null"
+            ]
+          },
+          "computer_use": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseConfig"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "desktop": {
@@ -8935,6 +9341,12 @@
             ]
           },
           "allowAppshots": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "allowBrowserAndComputerUse": {
             "type": [
               "boolean",
               "null"
@@ -13404,6 +13816,18 @@
         "title": "McpResourceReadResponse",
         "type": "object"
       },
+      "McpServerConnectionStatus": {
+        "enum": [
+          "notStarted",
+          "starting",
+          "connected",
+          "authenticationRequired",
+          "failed",
+          "cancelled",
+          "disabled"
+        ],
+        "type": "string"
+      },
       "McpServerEventNotification": {
         "properties": {
           "method": {
@@ -13627,6 +14051,17 @@
               "$ref": "#/definitions/v2/Resource"
             },
             "type": "array"
+          },
+          "runtimeStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/McpServerConnectionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Current thread-runtime connection state; null when unavailable or the configuration changed."
           },
           "serverInfo": {
             "anyOf": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -391,6 +391,13 @@
     "AgentPath": {
       "type": "string"
     },
+    "AllowDenyRequirement": {
+      "enum": [
+        "allow",
+        "deny"
+      ],
+      "type": "string"
+    },
     "AnalyticsConfig": {
       "additionalProperties": true,
       "properties": {
@@ -1280,11 +1287,195 @@
       },
       "type": "object"
     },
+    "BrowserUseAccessApprovalLifetime": {
+      "enum": [
+        "turn",
+        "thread"
+      ],
+      "type": "string"
+    },
+    "BrowserUseConfig": {
+      "properties": {
+        "allow_history_access": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "default_origin_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BrowserUseOriginPolicyConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "origins": {
+          "additionalProperties": {
+            "$ref": "#/definitions/BrowserUseOriginPolicyConfig"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "BrowserUseOriginPolicy": {
+      "properties": {
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "accessApprovalLifetime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BrowserUseAccessApprovalLifetime"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "autoReview": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "downloads": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "fullCdpAccess": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "persistentApproval": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "uploads": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "BrowserUseOriginPolicyConfig": {
+      "properties": {
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "downloads": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "full_cdp_access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "uploads": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "BrowserUseRequirements": {
       "properties": {
+        "allowGlobalPersistentApproval": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "allowHistoryAccess": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "defaultOriginPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BrowserUseOriginPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "disableAutoReview": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "origins": {
+          "additionalProperties": {
+            "$ref": "#/definitions/BrowserUseOriginPolicy"
+          },
+          "type": [
+            "object",
             "null"
           ]
         }
@@ -4403,11 +4594,206 @@
       ],
       "type": "object"
     },
+    "ComputerUseConfig": {
+      "properties": {
+        "default_app_access": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "macos": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseMacosConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "windows": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseWindowsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ComputerUseMacosConfig": {
+      "properties": {
+        "bundle_ids": {
+          "additionalProperties": {
+            "$ref": "#/definitions/AllowDenyRequirement"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ComputerUseMacosRequirements": {
+      "properties": {
+        "bundleIds": {
+          "additionalProperties": {
+            "$ref": "#/definitions/AllowDenyRequirement"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ComputerUseRequirements": {
       "properties": {
         "allowLockedComputerUse": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "allowPersistentApproval": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "defaultAppAccess": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowDenyRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "macos": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseMacosRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "windows": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseWindowsRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ComputerUseWindowsConfig": {
+      "properties": {
+        "aumids": {
+          "additionalProperties": {
+            "$ref": "#/definitions/AllowDenyRequirement"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "exes": {
+          "items": {
+            "$ref": "#/definitions/ComputerUseWindowsExeConfig"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ComputerUseWindowsExeConfig": {
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/AllowDenyRequirement"
+        },
+        "binary_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "product_name": {
+          "type": "string"
+        },
+        "publisher_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "access",
+        "product_name",
+        "publisher_name"
+      ],
+      "type": "object"
+    },
+    "ComputerUseWindowsExeRequirement": {
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/AllowDenyRequirement"
+        },
+        "binaryName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "productName": {
+          "type": "string"
+        },
+        "publisherName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "access",
+        "productName",
+        "publisherName"
+      ],
+      "type": "object"
+    },
+    "ComputerUseWindowsRequirements": {
+      "properties": {
+        "aumids": {
+          "additionalProperties": {
+            "$ref": "#/definitions/AllowDenyRequirement"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "exes": {
+          "items": {
+            "$ref": "#/definitions/ComputerUseWindowsExeRequirement"
+          },
+          "type": [
+            "array",
             "null"
           ]
         }
@@ -4448,10 +4834,30 @@
           ],
           "description": "[UNSTABLE] Optional default for where approval requests are routed for review."
         },
+        "browser_use": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BrowserUseConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "compact_prompt": {
           "type": [
             "string",
             "null"
+          ]
+        },
+        "computer_use": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "desktop": {
@@ -4973,6 +5379,12 @@
           ]
         },
         "allowAppshots": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "allowBrowserAndComputerUse": {
           "type": [
             "boolean",
             "null"
@@ -9614,6 +10026,18 @@
       "title": "McpResourceReadResponse",
       "type": "object"
     },
+    "McpServerConnectionStatus": {
+      "enum": [
+        "notStarted",
+        "starting",
+        "connected",
+        "authenticationRequired",
+        "failed",
+        "cancelled",
+        "disabled"
+      ],
+      "type": "string"
+    },
     "McpServerEventNotification": {
       "properties": {
         "method": {
@@ -9837,6 +10261,17 @@
             "$ref": "#/definitions/Resource"
           },
           "type": "array"
+        },
+        "runtimeStatus": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpServerConnectionStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Current thread-runtime connection state; null when unavailable or the configuration changed."
         },
         "serverInfo": {
           "anyOf": [


### PR DESCRIPTION
Fixes #330 — this morning's drift report, dedicated drift-only PR per the established pattern.

**Absorbed — upstream grew a browser-use / computer-use policy surface** (13 new definitions, 5 modeled types widened):
- `AllowDenyRequirement` + `BrowserUseAccessApprovalLifetime` + per-origin `BrowserUseOriginPolicy{,Config}`
- `ComputerUse{Macos,Windows}{Requirements,Config}` — macOS bundle-id maps, Windows AUMID maps and signed-exe allowlists
- Field adds: `BrowserUseRequirements` (+4), `ComputerUseRequirements` (+4), `Config.browser_use`/`computer_use`, `ConfigRequirements.allowBrowserAndComputerUse`, `McpServerStatus.runtimeStatus` (typed `McpServerConnectionStatus`, 7 states)
- One wire quirk mirrored exactly: **requirements types are camelCase, config types snake_case** — same concepts, different casing per side

**Verification:** both snapshots byte-identical per drift script; full test suite green; clippy clean; live wirecheck codex tier 5/5. 0.147.2 → 0.147.3 (crate-side patch; tested pin stays 0.147.0).