### PR TITLE
codex-codes 0.147.4: resnapshot vs openai/codex@main (fixes #332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.3"
+version = "0.147.4"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.3` (tested CLI + 3 crate-side patches), tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.147.4` (tested CLI + 4 crate-side patches), tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.4] - 2026-08-26
+
+### Added
+
+- Resnapshot vs `openai/codex@main` (fixes #332): the experimental
+  realtime-item timeline surface — `thread/realtime/item/{started,completed}`
+  and `thread/realtime/item/transcript/delta` notifications with
+  `ThreadRealtimeItem` (session-started / transcript-segment /
+  bem-item-promoted / session-closed payloads), `ThreadTimelineEntry`,
+  and three new paginated-history RPCs with typed `AsyncClient` helpers:
+  `thread/items/list`, `thread/turns/list`, and `thread/revert`
+  (plus `excludeTurns` on fork/resume params and backwards cursors on
+  `ThreadResumeResponse`). Also mirrored: `AuthMode::BedrockAccessKeys` +
+  `LoginAccountParams::AmazonBedrockAccessKeys`,
+  `CodexErrorInfo::RateLimitExceeded`, four new `CollabAgentTool` verbs
+  and an `interrupted` call status, `HookEventName::Interrupt`,
+  `GuardianApprovalReviewAction::WriteStdin`, the v1
+  `CommandExecutionApprovalKind` on command approvals,
+  `SkillMetadata.pluginId`, `Thread.historyMode`,
+  `TurnStartParams.{serviceTierForTurn,turnTrigger}`,
+  `SubAgentActivityKind::Completed`, and the `CyberAccessProgram` enum.
+
 ## [0.147.3] - 2026-08-22
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.3"
+version = "0.147.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/async_client.rs
+++ b/codex-codes/examples/async_client.rs
@@ -40,7 +40,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await?;
 

--- a/codex-codes/examples/basic_repl.rs
+++ b/codex-codes/examples/basic_repl.rs
@@ -59,7 +59,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 personality: None,
                 sandbox_policy: None,
                 service_tier: None,
+                service_tier_for_turn: None,
                 summary: None,
+                turn_trigger: None,
             })
             .await?;
 

--- a/codex-codes/examples/sync_client.rs
+++ b/codex-codes/examples/sync_client.rs
@@ -38,7 +38,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         personality: None,
         sandbox_policy: None,
         service_tier: None,
+        service_tier_for_turn: None,
         summary: None,
+        turn_trigger: None,
     })?;
 
     // Iterate notifications until the turn completes

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -51,9 +51,10 @@ use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
     ThreadDeleteParams, ThreadDeleteResponse, ThreadForkParams, ThreadForkResponse,
-    ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
-    TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
-    TurnSteerParams, TurnSteerResponse,
+    ThreadItemsListParams, ThreadItemsListResponse, ThreadResumeParams, ThreadResumeResponse,
+    ThreadRevertParams, ThreadRevertResponse, ThreadStartParams, ThreadStartResponse,
+    ThreadTurnsListParams, ThreadTurnsListResponse, TurnInterruptParams, TurnInterruptResponse,
+    TurnStartParams, TurnStartResponse, TurnSteerParams, TurnSteerResponse,
 };
 use crate::protocol_generated::types::{
     CancelLoginAccountParams, CancelLoginAccountResponse, GetAccountParams,
@@ -292,6 +293,37 @@ impl AsyncClient {
     /// appends to the running turn instead of starting a new one.
     pub async fn turn_steer(&mut self, params: &TurnSteerParams) -> Result<TurnSteerResponse> {
         self.request(crate::protocol::methods::TURN_STEER, params)
+            .await
+    }
+
+    /// Page through a thread's items in canonical order (`thread/items/list`).
+    /// Follow `next_cursor` for subsequent pages (0.148 upstream).
+    pub async fn thread_items_list(
+        &mut self,
+        params: &ThreadItemsListParams,
+    ) -> Result<ThreadItemsListResponse> {
+        self.request(crate::protocol::methods::THREAD_ITEMS_LIST, params)
+            .await
+    }
+
+    /// Page through a thread's turns (`thread/turns/list`); defaults to
+    /// newest-first with summary item detail (0.148 upstream).
+    pub async fn thread_turns_list(
+        &mut self,
+        params: &ThreadTurnsListParams,
+    ) -> Result<ThreadTurnsListResponse> {
+        self.request(crate::protocol::methods::THREAD_TURNS_LIST, params)
+            .await
+    }
+
+    /// Replace a paginated thread's durable history with the prefix before
+    /// one turn (`thread/revert`). Does not revert local file changes
+    /// (0.148 upstream).
+    pub async fn thread_revert(
+        &mut self,
+        params: &ThreadRevertParams,
+    ) -> Result<ThreadRevertResponse> {
+        self.request(crate::protocol::methods::THREAD_REVERT, params)
             .await
     }
 

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -50,13 +50,15 @@ use crate::protocol::{
     ThreadNameUpdatedNotification, ThreadProjectUpdatedNotification,
     ThreadQueueChangedNotification, ThreadRealtimeClosedNotification,
     ThreadRealtimeErrorNotification, ThreadRealtimeItemAddedNotification,
-    ThreadRealtimeOutputAudioDeltaNotification, ThreadRealtimeSdpNotification,
-    ThreadRealtimeStartedNotification, ThreadRealtimeTranscriptDeltaNotification,
-    ThreadRealtimeTranscriptDoneNotification, ThreadRevertedNotification,
-    ThreadSettingsUpdatedNotification, ThreadStartedNotification, ThreadStatusChangedNotification,
-    ThreadTokenUsageUpdatedNotification, ThreadUnarchivedNotification, TurnCompletedNotification,
-    TurnDiffUpdatedNotification, TurnModerationMetadataNotification, TurnPlanUpdatedNotification,
-    TurnStartedNotification, WarningNotification, WindowsSandboxSetupCompletedNotification,
+    ThreadRealtimeItemCompletedNotification, ThreadRealtimeItemStartedNotification,
+    ThreadRealtimeItemTranscriptDeltaNotification, ThreadRealtimeOutputAudioDeltaNotification,
+    ThreadRealtimeSdpNotification, ThreadRealtimeStartedNotification,
+    ThreadRealtimeTranscriptDeltaNotification, ThreadRealtimeTranscriptDoneNotification,
+    ThreadRevertedNotification, ThreadSettingsUpdatedNotification, ThreadStartedNotification,
+    ThreadStatusChangedNotification, ThreadTokenUsageUpdatedNotification,
+    ThreadUnarchivedNotification, TurnCompletedNotification, TurnDiffUpdatedNotification,
+    TurnModerationMetadataNotification, TurnPlanUpdatedNotification, TurnStartedNotification,
+    WarningNotification, WindowsSandboxSetupCompletedNotification,
     WindowsWorldWritableWarningNotification,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -221,6 +223,12 @@ pub enum Notification {
     ThreadReverted(ThreadRevertedNotification),
     /// `mcpServer/event/stream/notification` (0.148 upstream)
     McpServerEventStream(McpServerEventStreamNotification),
+    /// `thread/realtime/item/started` (0.148 upstream, experimental)
+    ThreadRealtimeItemStarted(ThreadRealtimeItemStartedNotification),
+    /// `thread/realtime/item/completed` (0.148 upstream, experimental)
+    ThreadRealtimeItemCompleted(ThreadRealtimeItemCompletedNotification),
+    /// `thread/realtime/item/transcript/delta` (0.148 upstream, experimental)
+    ThreadRealtimeItemTranscriptDelta(ThreadRealtimeItemTranscriptDeltaNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -241,6 +249,11 @@ impl Notification {
             Self::ThreadQueueChanged(_) => methods::THREAD_QUEUE_CHANGED,
             Self::ThreadReverted(_) => methods::THREAD_REVERTED,
             Self::McpServerEventStream(_) => methods::MCP_SERVER_EVENT_STREAM,
+            Self::ThreadRealtimeItemStarted(_) => methods::THREAD_REALTIME_ITEM_STARTED,
+            Self::ThreadRealtimeItemCompleted(_) => methods::THREAD_REALTIME_ITEM_COMPLETED,
+            Self::ThreadRealtimeItemTranscriptDelta(_) => {
+                methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA
+            }
             Self::ThreadStatusChanged(_) => methods::THREAD_STATUS_CHANGED,
             Self::ThreadTokenUsageUpdated(_) => methods::THREAD_TOKEN_USAGE_UPDATED,
             Self::TurnStarted(_) => methods::TURN_STARTED,
@@ -413,6 +426,15 @@ impl Notification {
             }
             methods::MCP_SERVER_EVENT_STREAM => {
                 serde_json::from_value(params_value).map(Self::McpServerEventStream)
+            }
+            methods::THREAD_REALTIME_ITEM_STARTED => {
+                serde_json::from_value(params_value).map(Self::ThreadRealtimeItemStarted)
+            }
+            methods::THREAD_REALTIME_ITEM_COMPLETED => {
+                serde_json::from_value(params_value).map(Self::ThreadRealtimeItemCompleted)
+            }
+            methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA => {
+                serde_json::from_value(params_value).map(Self::ThreadRealtimeItemTranscriptDelta)
             }
             methods::THREAD_STATUS_CHANGED => {
                 serde_json::from_value(params_value).map(Self::ThreadStatusChanged)
@@ -628,6 +650,13 @@ impl Notification {
             Self::ThreadQueueChanged(v) => pack(methods::THREAD_QUEUE_CHANGED, v),
             Self::ThreadReverted(v) => pack(methods::THREAD_REVERTED, v),
             Self::McpServerEventStream(v) => pack(methods::MCP_SERVER_EVENT_STREAM, v),
+            Self::ThreadRealtimeItemStarted(v) => pack(methods::THREAD_REALTIME_ITEM_STARTED, v),
+            Self::ThreadRealtimeItemCompleted(v) => {
+                pack(methods::THREAD_REALTIME_ITEM_COMPLETED, v)
+            }
+            Self::ThreadRealtimeItemTranscriptDelta(v) => {
+                pack(methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA, v)
+            }
             Self::ThreadStatusChanged(v) => pack(methods::THREAD_STATUS_CHANGED, v),
             Self::ThreadTokenUsageUpdated(v) => pack(methods::THREAD_TOKEN_USAGE_UPDATED, v),
             Self::TurnStarted(v) => pack(methods::TURN_STARTED, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -49,6 +49,9 @@ pub mod methods {
     pub const THREAD_LOADED_LIST: &str = "thread/loaded/list";
     pub const THREAD_READ: &str = "thread/read";
     pub const THREAD_INJECT_ITEMS: &str = "thread/inject_items";
+    pub const THREAD_ITEMS_LIST: &str = "thread/items/list";
+    pub const THREAD_TURNS_LIST: &str = "thread/turns/list";
+    pub const THREAD_REVERT: &str = "thread/revert";
     pub const SKILLS_LIST: &str = "skills/list";
     pub const HOOKS_LIST: &str = "hooks/list";
     pub const MARKETPLACE_ADD: &str = "marketplace/add";
@@ -196,6 +199,9 @@ pub mod methods {
     pub const THREAD_REALTIME_STARTED: &str = "thread/realtime/started";
     pub const THREAD_REALTIME_TRANSCRIPT_DELTA: &str = "thread/realtime/transcript/delta";
     pub const THREAD_REALTIME_TRANSCRIPT_DONE: &str = "thread/realtime/transcript/done";
+    pub const THREAD_REALTIME_ITEM_STARTED: &str = "thread/realtime/item/started";
+    pub const THREAD_REALTIME_ITEM_COMPLETED: &str = "thread/realtime/item/completed";
+    pub const THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA: &str = "thread/realtime/item/transcript/delta";
     pub const WINDOWS_WORLD_WRITABLE_WARNING: &str = "windows/worldWritableWarning";
     pub const WINDOWS_SANDBOX_SETUP_COMPLETED: &str = "windowsSandbox/setupCompleted";
     pub const THREAD_SETTINGS_UPDATED: &str = "thread/settings/updated";

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -598,6 +598,8 @@ pub enum AuthMode {
     PersonalAccessToken,
     #[serde(rename = "bedrockApiKey")]
     BedrockApiKey,
+    #[serde(rename = "bedrockAccessKeys")]
+    BedrockAccessKeys,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -746,6 +748,8 @@ pub enum CodexErrorInfo {
     SessionBudgetExceeded,
     #[serde(rename = "usageLimitExceeded")]
     UsageLimitExceeded,
+    #[serde(rename = "rateLimitExceeded")]
+    RateLimitExceeded,
     #[serde(rename = "serverOverloaded")]
     ServerOverloaded,
     #[serde(rename = "cyberPolicy")]
@@ -846,6 +850,14 @@ pub enum CollabAgentTool {
     Wait,
     #[serde(rename = "closeAgent")]
     CloseAgent,
+    #[serde(rename = "sendMessage")]
+    SendMessage,
+    #[serde(rename = "followupTask")]
+    FollowupTask,
+    #[serde(rename = "interruptAgent")]
+    InterruptAgent,
+    #[serde(rename = "listAgents")]
+    ListAgents,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -856,6 +868,20 @@ pub enum CollabAgentToolCallStatus {
     Completed,
     #[serde(rename = "failed")]
     Failed,
+    #[serde(rename = "interrupted")]
+    Interrupted,
+}
+
+/// Requested cyber treatment for a ChatGPT-authenticated turn; authorization
+/// and model-tier restrictions stay server-owned (0.148 upstream).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CyberAccessProgram {
+    #[serde(rename = "standard")]
+    Standard,
+    #[serde(rename = "daybreakBlue")]
+    DaybreakBlue,
+    #[serde(rename = "daybreakRed")]
+    DaybreakRed,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1063,6 +1089,16 @@ pub enum CommandExecutionApprovalDecision {
     Cancel,
 }
 
+/// Distinguishes a command approval from input sent to an existing terminal
+/// (v1 `commandExecution/requestApproval`, 0.148 upstream).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CommandExecutionApprovalKind {
+    #[serde(rename = "command")]
+    Command,
+    #[serde(rename = "writeStdin")]
+    WriteStdin,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandExecutionOutputDeltaNotification {
@@ -1103,6 +1139,10 @@ pub struct CommandExecutionRequestApprovalParams {
     pub environment_id: Option<String>,
     #[serde(rename = "itemId", default)]
     pub item_id: String,
+    /// Kind of action under review; defaults to `command` on older servers.
+    /// `writeStdin` marks input to an existing terminal (0.148 upstream).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CommandExecutionApprovalKind>,
     #[serde(
         rename = "networkApprovalContext",
         default,
@@ -2782,6 +2822,15 @@ pub enum GuardianApprovalReviewAction {
         program: String,
         source: GuardianCommandSource,
     },
+    #[serde(rename = "writeStdin")]
+    WriteStdin {
+        #[serde(rename = "approvalId")]
+        approval_id: String,
+        cwd: LegacyAppPathString,
+        #[serde(rename = "processId")]
+        process_id: String,
+        stdin: String,
+    },
     #[serde(rename = "applyPatch")]
     ApplyPatch {
         cwd: AbsolutePathBuf,
@@ -2921,6 +2970,8 @@ pub enum HookEventName {
     SubagentStop,
     #[serde(rename = "stop")]
     Stop,
+    #[serde(rename = "interrupt")]
+    Interrupt,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3435,6 +3486,20 @@ pub enum LoginAccountParams {
         #[serde(rename = "apiKey")]
         api_key: String,
         region: String,
+    },
+    #[serde(rename = "amazonBedrockAccessKeys")]
+    AmazonBedrockAccessKeys {
+        #[serde(rename = "accessKeyId")]
+        access_key_id: String,
+        region: String,
+        #[serde(rename = "secretAccessKey")]
+        secret_access_key: String,
+        #[serde(
+            rename = "sessionToken",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        session_token: Option<String>,
     },
 }
 
@@ -6459,6 +6524,8 @@ pub struct SkillMetadata {
     pub name: String,
     #[serde()]
     pub path: AbsolutePathBuf,
+    #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
+    pub plugin_id: Option<String>,
     #[serde()]
     pub scope: SkillScope,
     #[serde(
@@ -6625,6 +6692,8 @@ pub enum SubAgentActivityKind {
     Interacted,
     #[serde(rename = "interrupted")]
     Interrupted,
+    #[serde(rename = "completed")]
+    Completed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -6726,6 +6795,14 @@ pub struct Thread {
     pub forked_from_id: Option<String>,
     #[serde(rename = "gitInfo", default, skip_serializing_if = "Option::is_none")]
     pub git_info: Option<GitInfo>,
+    /// Persisted history contract chosen at thread creation (0.148 upstream);
+    /// absent on older servers, which are always `legacy`.
+    #[serde(
+        rename = "historyMode",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub history_mode: Option<ThreadHistoryMode>,
     /// Canonical project assignment owned by app-server, if any. Required
     /// upstream from 0.147 but kept tolerant for pre-project servers.
     #[serde(rename = "projectId", default, skip_serializing_if = "Option::is_none")]
@@ -6894,6 +6971,12 @@ pub struct ThreadForkParams {
     pub developer_instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ephemeral: Option<bool>,
+    #[serde(
+        rename = "excludeTurns",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub exclude_turns: Option<bool>,
     #[serde(
         rename = "lastTurnId",
         default,
@@ -7632,6 +7715,12 @@ pub struct ThreadResumeParams {
     pub service_tier: Option<String>,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+    #[serde(
+        rename = "excludeTurns",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub exclude_turns: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -7649,6 +7738,14 @@ pub struct ThreadResumeResponse {
         skip_serializing_if = "Option::is_none"
     )]
     pub instruction_sources: Option<Vec<LegacyAppPathString>>,
+    /// Cursor for hydrating paginated items backwards via `thread/items/list`
+    /// with `sortDirection: "desc"` (0.148 upstream).
+    #[serde(
+        rename = "itemsBackwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub items_backwards_cursor: Option<String>,
     #[serde(default)]
     pub model: String,
     #[serde(rename = "modelProvider", default)]
@@ -7669,6 +7766,209 @@ pub struct ThreadResumeResponse {
     pub service_tier: Option<String>,
     #[serde()]
     pub thread: Thread,
+    /// Cursor for hydrating paginated turns backwards via `thread/turns/list`
+    /// with `sortDirection: "desc"` (0.148 upstream).
+    #[serde(
+        rename = "turnsBackwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub turns_backwards_cursor: Option<String>,
+}
+
+/// Persisted thread history contract (0.148 upstream).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ThreadHistoryMode {
+    #[serde(rename = "legacy")]
+    Legacy,
+    #[serde(rename = "paginated")]
+    Paginated,
+}
+
+/// One item plus the turn that contains it, as returned by
+/// `thread/items/list` (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadItemEntry {
+    #[serde()]
+    pub item: ThreadItem,
+    #[serde(rename = "turnId", default)]
+    pub turn_id: String,
+}
+
+/// Params for `thread/items/list` — paginated item hydration (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadItemsListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(
+        rename = "sortDirection",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sort_direction: Option<SortDirection>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    /// Optional turn id filter; omitted returns items across the thread.
+    #[serde(rename = "turnId", default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+/// Response to `thread/items/list` (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadItemsListResponse {
+    #[serde(
+        rename = "backwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub backwards_cursor: Option<String>,
+    #[serde(default)]
+    pub data: Vec<ThreadItemEntry>,
+    #[serde(
+        rename = "nextCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
+/// EXPERIMENTAL upstream — a thread-scoped realtime item in the canonical
+/// timeline (0.148). Top-level identity fields are camelCase on the wire
+/// while variant payload fields are snake_case; mirrored exactly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThreadRealtimeItem {
+    #[serde(default)]
+    pub id: String,
+    #[serde(rename = "realtimeSessionId", default)]
+    pub realtime_session_id: String,
+    #[serde(flatten)]
+    pub detail: ThreadRealtimeItemDetail,
+}
+
+/// The `type`-tagged payload of a [`ThreadRealtimeItem`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ThreadRealtimeItemDetail {
+    #[serde(rename = "realtimeSessionStarted")]
+    RealtimeSessionStarted,
+    #[serde(rename = "transcriptSegment")]
+    TranscriptSegment {
+        role: ThreadRealtimeTranscriptRole,
+        text: String,
+    },
+    #[serde(rename = "bemItemPromoted")]
+    BemItemPromoted {
+        item_id: String,
+        presentation: ThreadRealtimeBemItemPresentation,
+        turn_id: String,
+    },
+    #[serde(rename = "realtimeSessionClosed")]
+    RealtimeSessionClosed {
+        outcome: ThreadRealtimeSessionOutcome,
+    },
+}
+
+/// EXPERIMENTAL upstream — how an existing agent item appears in a realtime
+/// conversation (0.148).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ThreadRealtimeBemItemPresentation {
+    #[serde(rename = "wholeItem")]
+    WholeItem,
+    #[serde(rename = "inlineMarkdown")]
+    InlineMarkdown,
+    #[serde(rename = "inlineVisualization")]
+    InlineVisualization { index: u32 },
+}
+
+/// EXPERIMENTAL upstream — `thread/realtime/item/started` params (0.148).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadRealtimeItemStartedNotification {
+    #[serde()]
+    pub item: ThreadRealtimeItem,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// EXPERIMENTAL upstream — `thread/realtime/item/completed` params (0.148).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadRealtimeItemCompletedNotification {
+    #[serde()]
+    pub item: ThreadRealtimeItem,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// EXPERIMENTAL upstream — `thread/realtime/item/transcript/delta` params:
+/// text appended to an active realtime transcript item (0.148).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadRealtimeItemTranscriptDeltaNotification {
+    #[serde(default)]
+    pub delta: String,
+    #[serde(rename = "itemId", default)]
+    pub item_id: String,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// EXPERIMENTAL upstream — outcome of a closed realtime session (0.148).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ThreadRealtimeSessionOutcome {
+    #[serde(rename = "ended")]
+    Ended,
+    #[serde(rename = "failed")]
+    Failed,
+}
+
+/// EXPERIMENTAL upstream — speaker role in a realtime transcript (0.148).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ThreadRealtimeTranscriptRole {
+    #[serde(rename = "user")]
+    User,
+    #[serde(rename = "assistant")]
+    Assistant,
+}
+
+/// Params for `thread/revert` — replace a paginated thread's durable history
+/// with the prefix before one turn; local file changes are untouched
+/// (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadRevertParams {
+    /// Turn excluded from the replacement history, with every later turn.
+    #[serde(rename = "beforeTurnId", default)]
+    pub before_turn_id: String,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// Response to `thread/revert` (0.148 upstream). `thread.turns` is always
+/// empty; retained history hydrates through `thread/turns/list`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadRevertResponse {
+    #[serde(
+        rename = "itemsBackwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub items_backwards_cursor: Option<String>,
+    #[serde()]
+    pub thread: Thread,
+    #[serde(
+        rename = "turnsBackwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub turns_backwards_cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -8110,6 +8410,86 @@ pub struct ThreadUnarchivedNotification {
     pub thread_id: String,
 }
 
+/// EXPERIMENTAL upstream — one item or turn boundary in canonical rollout
+/// order (0.148). Wire quirk mirrored exactly: the `item` variant uses
+/// camelCase `turnId` while the turn-boundary variants use snake_case
+/// `turn_id`/`started_at`/`completed_at`/`duration_ms`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)] // transient per-entry wire value, not stored in bulk
+pub enum ThreadTimelineEntry {
+    Item {
+        item: ThreadItem,
+        position: u64,
+        #[serde(rename = "turnId")]
+        turn_id: String,
+    },
+    Realtime {
+        item: ThreadRealtimeItem,
+        position: u64,
+    },
+    TurnStarted {
+        position: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        started_at: Option<i64>,
+        turn_id: String,
+    },
+    TurnCompleted {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        completed_at: Option<i64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<i64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<TurnError>,
+        position: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        started_at: Option<i64>,
+        status: TurnStatus,
+        turn_id: String,
+    },
+}
+
+/// Params for `thread/turns/list` — paginated turn hydration (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadTurnsListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// How much item detail to include per turn; defaults to summary.
+    #[serde(rename = "itemsView", default, skip_serializing_if = "Option::is_none")]
+    pub items_view: Option<TurnItemsView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(
+        rename = "sortDirection",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sort_direction: Option<SortDirection>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// Response to `thread/turns/list` (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadTurnsListResponse {
+    #[serde(
+        rename = "backwardsCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub backwards_cursor: Option<String>,
+    #[serde(default)]
+    pub data: Vec<Turn>,
+    #[serde(
+        rename = "nextCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadUnsubscribeParams {
@@ -8434,10 +8814,26 @@ pub struct TurnStartParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub service_tier: Option<String>,
+    /// One-turn service-tier override; `"default"` for standard speed.
+    /// Omitted or null inherits the thread's tier (0.148 upstream).
+    #[serde(
+        rename = "serviceTierForTurn",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_tier_for_turn: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<ReasoningSummary>,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+    /// Optional source classification for the caller starting this turn;
+    /// ignored when steering an already-active turn (0.148 upstream).
+    #[serde(
+        rename = "turnTrigger",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub turn_trigger: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -73,7 +73,9 @@ async fn test_async_client_thread_fork() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start seed turn");
@@ -147,7 +149,9 @@ async fn test_async_client_basic_turn() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start turn");
@@ -275,7 +279,9 @@ fn test_sync_client_basic_turn() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .expect("Failed to start turn");
 
@@ -341,7 +347,9 @@ async fn test_async_client_multi_turn() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start first turn");
@@ -384,7 +392,9 @@ async fn test_async_client_multi_turn() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start second turn");
@@ -449,7 +459,9 @@ async fn test_async_client_event_stream() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start turn");
@@ -526,7 +538,9 @@ async fn test_typed_message_audit_strict() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("Failed to start turn");
@@ -634,6 +648,11 @@ async fn test_typed_message_audit_strict() {
                         "ThreadRealtimeTranscriptDelta"
                     }
                     Notification::ThreadRealtimeTranscriptDone(_) => "ThreadRealtimeTranscriptDone",
+                    Notification::ThreadRealtimeItemStarted(_) => "ThreadRealtimeItemStarted",
+                    Notification::ThreadRealtimeItemCompleted(_) => "ThreadRealtimeItemCompleted",
+                    Notification::ThreadRealtimeItemTranscriptDelta(_) => {
+                        "ThreadRealtimeItemTranscriptDelta"
+                    }
                     Notification::WindowsWorldWritableWarning(_) => "WindowsWorldWritableWarning",
                     Notification::WindowsSandboxSetupCompleted(_) => "WindowsSandboxSetupCompleted",
                     Notification::Unknown { method, .. } => {
@@ -772,7 +791,9 @@ async fn test_async_client_writes_compilable_quicksort() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("turn_start");
@@ -953,7 +974,9 @@ async fn test_thread_resume_reopens_thread_via_typed_helper() {
             personality: None,
             sandbox_policy: None,
             service_tier: None,
+            service_tier_for_turn: None,
             summary: None,
+            turn_trigger: None,
         })
         .await
         .expect("seed turn");

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -643,6 +643,30 @@
             },
             "method": {
               "enum": [
+                "thread/revert"
+              ],
+              "title": "Thread/revertRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadRevertParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/revertRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/list"
               ],
               "title": "Thread/listRequestMethod",
@@ -802,6 +826,54 @@
             "params"
           ],
           "title": "Thread/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/turns/list"
+              ],
+              "title": "Thread/turns/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadTurnsListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/turns/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/items/list"
+              ],
+              "title": "Thread/items/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadItemsListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/items/listRequest",
           "type": "object"
         },
         {
@@ -2570,11 +2642,19 @@
         }
       ]
     },
+    "CommandExecutionApprovalKind": {
+      "description": "Distinguishes a command approval from input sent to an existing terminal.",
+      "enum": [
+        "command",
+        "writeStdin"
+      ],
+      "type": "string"
+    },
     "CommandExecutionRequestApprovalParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "approvalId": {
-          "description": "Unique identifier for this specific approval callback.\n\nFor regular shell/unified_exec approvals, this is null.\n\nFor zsh-exec-bridge subcommand approvals, multiple callbacks can belong to one parent `itemId`, so `approvalId` is a distinct opaque callback id (a UUID) used to disambiguate routing.",
+          "description": "Unique identifier for this specific approval callback.\n\nFor regular shell/unified_exec approvals, this is null.\n\nFor zsh-exec-bridge subcommand approvals, multiple callbacks can belong to one parent `itemId`, so `approvalId` is a distinct opaque callback id (a UUID) used to disambiguate routing. Stdin approvals also use a distinct callback id; inspect `kind` to distinguish them.",
           "type": [
             "string",
             "null"
@@ -2618,6 +2698,15 @@
         },
         "itemId": {
           "type": "string"
+        },
+        "kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandExecutionApprovalKind"
+            }
+          ],
+          "default": "command",
+          "description": "Kind of action under review. Defaults to `command` for older servers."
         },
         "networkApprovalContext": {
           "anyOf": [
@@ -5687,6 +5776,66 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/realtime/item/started"
+              ],
+              "title": "Thread/realtime/item/startedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadRealtimeItemStartedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/startedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/realtime/item/transcript/delta"
+              ],
+              "title": "Thread/realtime/item/transcript/deltaNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadRealtimeItemTranscriptDeltaNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/transcript/deltaNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/realtime/item/completed"
+              ],
+              "title": "Thread/realtime/item/completedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadRealtimeItemCompletedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/completedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/realtime/transcript/delta"
               ],
               "title": "Thread/realtime/transcript/deltaNotificationMethod",
@@ -7510,6 +7659,13 @@
               "bedrockApiKey"
             ],
             "type": "string"
+          },
+          {
+            "description": "Amazon Bedrock AWS access keys managed by Codex.",
+            "enum": [
+              "bedrockAccessKeys"
+            ],
+            "type": "string"
           }
         ]
       },
@@ -7857,6 +8013,7 @@
               "contextWindowExceeded",
               "sessionBudgetExceeded",
               "usageLimitExceeded",
+              "rateLimitExceeded",
               "serverOverloaded",
               "cyberPolicy",
               "misalignmentPolicyViolation",
@@ -8031,7 +8188,11 @@
           "sendInput",
           "resumeAgent",
           "wait",
-          "closeAgent"
+          "closeAgent",
+          "sendMessage",
+          "followupTask",
+          "interruptAgent",
+          "listAgents"
         ],
         "type": "string"
       },
@@ -8039,7 +8200,8 @@
         "enum": [
           "inProgress",
           "completed",
-          "failed"
+          "failed",
+          "interrupted"
         ],
         "type": "string"
       },
@@ -10094,6 +10256,15 @@
           "unlimited"
         ],
         "type": "object"
+      },
+      "CyberAccessProgram": {
+        "description": "Requested cyber treatment for a ChatGPT-authenticated Codex turn. Authorization and model-tier restrictions remain server-owned.",
+        "enum": [
+          "standard",
+          "daybreakBlue",
+          "daybreakRed"
+        ],
+        "type": "string"
       },
       "DeprecationNoticeNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -12159,6 +12330,39 @@
             "type": "object"
           },
           {
+            "description": "A child approval for input to an existing command execution item.",
+            "properties": {
+              "approvalId": {
+                "type": "string"
+              },
+              "cwd": {
+                "$ref": "#/definitions/v2/LegacyAppPathString"
+              },
+              "processId": {
+                "type": "string"
+              },
+              "stdin": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "writeStdin"
+                ],
+                "title": "WriteStdinGuardianApprovalReviewActionType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "approvalId",
+              "cwd",
+              "processId",
+              "stdin",
+              "type"
+            ],
+            "title": "WriteStdinGuardianApprovalReviewAction",
+            "type": "object"
+          },
+          {
             "properties": {
               "cwd": {
                 "$ref": "#/definitions/v2/AbsolutePathBuf"
@@ -12396,7 +12600,8 @@
           "userPromptSubmit",
           "subagentStart",
           "subagentStop",
-          "stop"
+          "stop",
+          "interrupt"
         ],
         "type": "string"
       },
@@ -13000,7 +13205,7 @@
             "type": "integer"
           },
           "targetItemId": {
-            "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
+            "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - stdin reviews, which refer to the existing parent command item and have a separate approval ID in the action payload - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
             "type": [
               "string",
               "null"
@@ -13046,7 +13251,7 @@
             "type": "integer"
           },
           "targetItemId": {
-            "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
+            "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - stdin reviews, which refer to the existing parent command item and have a separate approval ID in the action payload - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
             "type": [
               "string",
               "null"
@@ -13357,6 +13562,41 @@
             ],
             "title": "AmazonBedrockv2::LoginAccountParams",
             "type": "object"
+          },
+          {
+            "description": "[UNSTABLE] Managed Amazon Bedrock AWS access key login is experimental.",
+            "properties": {
+              "accessKeyId": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "secretAccessKey": {
+                "type": "string"
+              },
+              "sessionToken": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "amazonBedrockAccessKeys"
+                ],
+                "title": "AmazonBedrockAccessKeysv2::LoginAccountParamsType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "accessKeyId",
+              "region",
+              "secretAccessKey",
+              "type"
+            ],
+            "title": "AmazonBedrockAccessKeysv2::LoginAccountParams",
+            "type": "object"
           }
         ],
         "title": "LoginAccountParams"
@@ -13484,6 +13724,13 @@
       },
       "ManagedHooksRequirements": {
         "properties": {
+          "Interrupt": {
+            "default": [],
+            "items": {
+              "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
+            },
+            "type": "array"
+          },
           "PermissionRequest": {
             "items": {
               "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
@@ -19053,6 +19300,13 @@
           "path": {
             "$ref": "#/definitions/v2/AbsolutePathBuf"
           },
+          "pluginId": {
+            "description": "Owning plugin ID, matching `PluginSummary.id`, when known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "scope": {
             "$ref": "#/definitions/v2/SkillScope"
           },
@@ -19366,7 +19620,8 @@
         "enum": [
           "started",
           "interacted",
-          "interrupted"
+          "interrupted",
+          "completed"
         ],
         "type": "string"
       },
@@ -19599,6 +19854,15 @@
               }
             ],
             "description": "Optional Git metadata captured when the thread was created."
+          },
+          "historyMode": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadHistoryMode"
+              }
+            ],
+            "default": "legacy",
+            "description": "Persisted thread history contract selected when this thread was created."
           },
           "id": {
             "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
@@ -19907,6 +20171,10 @@
             ]
           },
           "ephemeral": {
+            "type": "boolean"
+          },
+          "excludeTurns": {
+            "description": "When true, return only thread metadata and live fork state without populating `thread.turns`. This is useful when the client plans to call `thread/turns/list` immediately after forking. Full-history hydration is deprecated for paginated threads; use this with `thread/turns/list` and `thread/items/list` instead.",
             "type": "boolean"
           },
           "lastTurnId": {
@@ -21087,6 +21355,83 @@
         ],
         "type": "object"
       },
+      "ThreadItemsListParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "cursor": {
+            "description": "Opaque cursor to pass to the next call to continue after the last item.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "description": "Optional item page size.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sortDirection": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/SortDirection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional item pagination direction; defaults to ascending."
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "turnId": {
+            "description": "Optional turn id to filter by. When omitted, returns items across the thread.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadItemsListParams",
+        "type": "object"
+      },
+      "ThreadItemsListResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "backwardsCursor": {
+            "description": "Opaque cursor to pass as `cursor` when reversing `sortDirection`. This is only populated when the page contains at least one item.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/ThreadItemEntry"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "description": "Opaque cursor to pass to the next call to continue after the last item. if None, there are no more items to return.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ThreadItemsListResponse",
+        "type": "object"
+      },
       "ThreadListCwdFilter": {
         "anyOf": [
           {
@@ -21404,7 +21749,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
           "includeTurns": {
-            "description": "When true, include turns and their items from rollout history.",
+            "description": "When true, include turns and their items from rollout history. Full-history hydration is deprecated for paginated threads; prefer a metadata-only read and page with `thread/turns/list` and `thread/items/list`.",
             "type": "boolean"
           },
           "threadId": {
@@ -21468,6 +21813,65 @@
         ],
         "type": "object"
       },
+      "ThreadRealtimeBemItemPresentation": {
+        "description": "EXPERIMENTAL - how an existing agent item appears in a realtime conversation.",
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "wholeItem"
+                ],
+                "title": "WholeItemThreadRealtimeBemItemPresentationType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "title": "WholeItemThreadRealtimeBemItemPresentation",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "inlineMarkdown"
+                ],
+                "title": "InlineMarkdownThreadRealtimeBemItemPresentationType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "title": "InlineMarkdownThreadRealtimeBemItemPresentation",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "index": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "type": {
+                "enum": [
+                  "inlineVisualization"
+                ],
+                "title": "InlineVisualizationThreadRealtimeBemItemPresentationType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "index",
+              "type"
+            ],
+            "title": "InlineVisualizationThreadRealtimeBemItemPresentation",
+            "type": "object"
+          }
+        ]
+      },
       "ThreadRealtimeClosedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "EXPERIMENTAL - emitted when thread realtime transport closes.",
@@ -21522,6 +21926,112 @@
         ],
         "type": "object"
       },
+      "ThreadRealtimeItem": {
+        "description": "EXPERIMENTAL - a thread-scoped realtime item in the canonical timeline.",
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "realtimeSessionStarted"
+                ],
+                "title": "RealtimeSessionStartedThreadRealtimeItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "title": "RealtimeSessionStartedThreadRealtimeItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "role": {
+                "$ref": "#/definitions/v2/ThreadRealtimeTranscriptRole"
+              },
+              "text": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "transcriptSegment"
+                ],
+                "title": "TranscriptSegmentThreadRealtimeItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "role",
+              "text",
+              "type"
+            ],
+            "title": "TranscriptSegmentThreadRealtimeItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "item_id": {
+                "type": "string"
+              },
+              "presentation": {
+                "$ref": "#/definitions/v2/ThreadRealtimeBemItemPresentation"
+              },
+              "turn_id": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "bemItemPromoted"
+                ],
+                "title": "BemItemPromotedThreadRealtimeItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "item_id",
+              "presentation",
+              "turn_id",
+              "type"
+            ],
+            "title": "BemItemPromotedThreadRealtimeItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "outcome": {
+                "$ref": "#/definitions/v2/ThreadRealtimeSessionOutcome"
+              },
+              "type": {
+                "enum": [
+                  "realtimeSessionClosed"
+                ],
+                "title": "RealtimeSessionClosedThreadRealtimeItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "outcome",
+              "type"
+            ],
+            "title": "RealtimeSessionClosedThreadRealtimeItem",
+            "type": "object"
+          }
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "realtimeSessionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "realtimeSessionId"
+        ],
+        "type": "object"
+      },
       "ThreadRealtimeItemAddedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.",
@@ -21536,6 +22046,64 @@
           "threadId"
         ],
         "title": "ThreadRealtimeItemAddedNotification",
+        "type": "object"
+      },
+      "ThreadRealtimeItemCompletedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "EXPERIMENTAL - a realtime timeline item published after canonical commit.",
+        "properties": {
+          "item": {
+            "$ref": "#/definitions/v2/ThreadRealtimeItem"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "item",
+          "threadId"
+        ],
+        "title": "ThreadRealtimeItemCompletedNotification",
+        "type": "object"
+      },
+      "ThreadRealtimeItemStartedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "EXPERIMENTAL - a realtime timeline item started before its content streams.",
+        "properties": {
+          "item": {
+            "$ref": "#/definitions/v2/ThreadRealtimeItem"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "item",
+          "threadId"
+        ],
+        "title": "ThreadRealtimeItemStartedNotification",
+        "type": "object"
+      },
+      "ThreadRealtimeItemTranscriptDeltaNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "EXPERIMENTAL - text appended to an active realtime transcript item.",
+        "properties": {
+          "delta": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "delta",
+          "itemId",
+          "threadId"
+        ],
+        "title": "ThreadRealtimeItemTranscriptDeltaNotification",
         "type": "object"
       },
       "ThreadRealtimeOutputAudioDeltaNotification": {
@@ -21573,6 +22141,13 @@
         ],
         "title": "ThreadRealtimeSdpNotification",
         "type": "object"
+      },
+      "ThreadRealtimeSessionOutcome": {
+        "enum": [
+          "ended",
+          "failed"
+        ],
+        "type": "string"
       },
       "ThreadRealtimeStartTransport": {
         "description": "EXPERIMENTAL - transport used by thread realtime.",
@@ -21707,6 +22282,13 @@
         "title": "ThreadRealtimeTranscriptDoneNotification",
         "type": "object"
       },
+      "ThreadRealtimeTranscriptRole": {
+        "enum": [
+          "user",
+          "assistant"
+        ],
+        "type": "string"
+      },
       "ThreadResumeInitialTurnsPageParams": {
         "properties": {
           "itemsView": {
@@ -21793,6 +22375,10 @@
               "null"
             ]
           },
+          "excludeTurns": {
+            "description": "When true, return only thread metadata and live-resume state without populating `thread.turns`. This is useful when the client plans to call `thread/turns/list` immediately after resuming. Full-history hydration is deprecated for paginated threads; use this with `thread/turns/list` and `thread/items/list` instead.",
+            "type": "boolean"
+          },
           "model": {
             "description": "Configuration overrides for the resumed thread, if any.",
             "type": [
@@ -21867,6 +22453,14 @@
             },
             "type": "array"
           },
+          "itemsBackwardsCursor": {
+            "default": null,
+            "description": "Opaque cursor for hydrating paginated items backwards.\n\nPass this as `cursor` to `thread/items/list` with `sortDirection: \"desc\"`. The first page includes the item identified by the cursor.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "model": {
             "type": "string"
           },
@@ -21899,6 +22493,14 @@
           },
           "thread": {
             "$ref": "#/definitions/v2/Thread"
+          },
+          "turnsBackwardsCursor": {
+            "default": null,
+            "description": "Opaque cursor for hydrating paginated turns backwards.\n\nPass this as `cursor` to `thread/turns/list` with `sortDirection: \"desc\"`. The first page includes the turn identified by the cursor.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -21911,6 +22513,57 @@
           "thread"
         ],
         "title": "ThreadResumeResponse",
+        "type": "object"
+      },
+      "ThreadRevertParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Replace a paginated thread's durable history with the prefix before one turn.\n\nThis only changes persisted conversation history. It does not revert local file changes.",
+        "properties": {
+          "beforeTurnId": {
+            "description": "Turn excluded from the replacement history, together with every later turn.",
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "beforeTurnId",
+          "threadId"
+        ],
+        "title": "ThreadRevertParams",
+        "type": "object"
+      },
+      "ThreadRevertResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "itemsBackwardsCursor": {
+            "description": "Opaque cursor for hydrating paginated items backwards.\n\nPass this as `cursor` to `thread/items/list` with `sortDirection: \"desc\"`. The first page includes the item identified by the cursor.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "thread": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/v2/Thread"
+              }
+            ],
+            "description": "Updated loaded thread metadata. `turns` is always empty; hydrate retained history through `thread/turns/list`."
+          },
+          "turnsBackwardsCursor": {
+            "description": "Opaque cursor for hydrating paginated turns backwards.\n\nPass this as `cursor` to `thread/turns/list` with `sortDirection: \"desc\"`. The first page includes the turn identified by the cursor.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "thread"
+        ],
+        "title": "ThreadRevertResponse",
         "type": "object"
       },
       "ThreadRevertedNotification": {
@@ -22702,6 +23355,161 @@
         "title": "ThreadStatusChangedNotification",
         "type": "object"
       },
+      "ThreadTimelineEntry": {
+        "description": "EXPERIMENTAL - one item or turn boundary in canonical rollout order.",
+        "oneOf": [
+          {
+            "properties": {
+              "item": {
+                "$ref": "#/definitions/v2/ThreadItem"
+              },
+              "position": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "turnId": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "item"
+                ],
+                "title": "ItemThreadTimelineEntryType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "item",
+              "position",
+              "turnId",
+              "type"
+            ],
+            "title": "ItemThreadTimelineEntry",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "item": {
+                "$ref": "#/definitions/v2/ThreadRealtimeItem"
+              },
+              "position": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "type": {
+                "enum": [
+                  "realtime"
+                ],
+                "title": "RealtimeThreadTimelineEntryType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "item",
+              "position",
+              "type"
+            ],
+            "title": "RealtimeThreadTimelineEntry",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "position": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "started_at": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "turn_id": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "turnStarted"
+                ],
+                "title": "TurnStartedThreadTimelineEntryType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "position",
+              "turn_id",
+              "type"
+            ],
+            "title": "TurnStartedThreadTimelineEntry",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "completed_at": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "duration_ms": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/TurnError"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "position": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "started_at": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "status": {
+                "$ref": "#/definitions/v2/TurnStatus"
+              },
+              "turn_id": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "turnCompleted"
+                ],
+                "title": "TurnCompletedThreadTimelineEntryType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "position",
+              "status",
+              "turn_id",
+              "type"
+            ],
+            "title": "TurnCompletedThreadTimelineEntry",
+            "type": "object"
+          }
+        ]
+      },
       "ThreadTokenUsage": {
         "properties": {
           "last": {
@@ -22743,6 +23551,87 @@
           "turnId"
         ],
         "title": "ThreadTokenUsageUpdatedNotification",
+        "type": "object"
+      },
+      "ThreadTurnsListParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "cursor": {
+            "description": "Opaque cursor to pass to the next call to continue after the last turn.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "itemsView": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/TurnItemsView"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How much item detail to include for each returned turn; defaults to summary."
+          },
+          "limit": {
+            "description": "Optional turn page size.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sortDirection": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/SortDirection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional turn pagination direction; defaults to descending."
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadTurnsListParams",
+        "type": "object"
+      },
+      "ThreadTurnsListResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "backwardsCursor": {
+            "description": "Opaque cursor to pass as `cursor` when reversing `sortDirection`. This is only populated when the page contains at least one turn. Use it with the opposite `sortDirection` to include the anchor turn again and catch updates to that turn.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/Turn"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "description": "Opaque cursor to pass to the next call to continue after the last turn. if None, there are no more turns to return.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ThreadTurnsListResponse",
         "type": "object"
       },
       "ThreadUnarchiveParams": {
@@ -23374,6 +24263,13 @@
               "null"
             ]
           },
+          "serviceTierForTurn": {
+            "description": "Override the service tier only when this request starts a new turn. Use \"default\" for standard speed. Omitted or null inherits the thread's tier. Does not change the thread's tier or a turn being steered.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "summary": {
             "anyOf": [
               {
@@ -23387,6 +24283,13 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "turnTrigger": {
+            "description": "Optional source classification for the caller that starts this turn. Ignored when this request steers an already-active turn.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -1235,6 +1235,13 @@
             "bedrockApiKey"
           ],
           "type": "string"
+        },
+        {
+          "description": "Amazon Bedrock AWS access keys managed by Codex.",
+          "enum": [
+            "bedrockAccessKeys"
+          ],
+          "type": "string"
         }
       ]
     },
@@ -2039,6 +2046,30 @@
             },
             "method": {
               "enum": [
+                "thread/revert"
+              ],
+              "title": "Thread/revertRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadRevertParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/revertRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/list"
               ],
               "title": "Thread/listRequestMethod",
@@ -2198,6 +2229,54 @@
             "params"
           ],
           "title": "Thread/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/turns/list"
+              ],
+              "title": "Thread/turns/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadTurnsListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/turns/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/items/list"
+              ],
+              "title": "Thread/items/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadItemsListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/items/listRequest",
           "type": "object"
         },
         {
@@ -3895,6 +3974,7 @@
             "contextWindowExceeded",
             "sessionBudgetExceeded",
             "usageLimitExceeded",
+            "rateLimitExceeded",
             "serverOverloaded",
             "cyberPolicy",
             "misalignmentPolicyViolation",
@@ -4069,7 +4149,11 @@
         "sendInput",
         "resumeAgent",
         "wait",
-        "closeAgent"
+        "closeAgent",
+        "sendMessage",
+        "followupTask",
+        "interruptAgent",
+        "listAgents"
       ],
       "type": "string"
     },
@@ -4077,7 +4161,8 @@
       "enum": [
         "inProgress",
         "completed",
-        "failed"
+        "failed",
+        "interrupted"
       ],
       "type": "string"
     },
@@ -6132,6 +6217,15 @@
         "unlimited"
       ],
       "type": "object"
+    },
+    "CyberAccessProgram": {
+      "description": "Requested cyber treatment for a ChatGPT-authenticated Codex turn. Authorization and model-tier restrictions remain server-owned.",
+      "enum": [
+        "standard",
+        "daybreakBlue",
+        "daybreakRed"
+      ],
+      "type": "string"
     },
     "DeprecationNoticeNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -8308,6 +8402,39 @@
           "type": "object"
         },
         {
+          "description": "A child approval for input to an existing command execution item.",
+          "properties": {
+            "approvalId": {
+              "type": "string"
+            },
+            "cwd": {
+              "$ref": "#/definitions/LegacyAppPathString"
+            },
+            "processId": {
+              "type": "string"
+            },
+            "stdin": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "writeStdin"
+              ],
+              "title": "WriteStdinGuardianApprovalReviewActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "approvalId",
+            "cwd",
+            "processId",
+            "stdin",
+            "type"
+          ],
+          "title": "WriteStdinGuardianApprovalReviewAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "cwd": {
               "$ref": "#/definitions/AbsolutePathBuf"
@@ -8545,7 +8672,8 @@
         "userPromptSubmit",
         "subagentStart",
         "subagentStop",
-        "stop"
+        "stop",
+        "interrupt"
       ],
       "type": "string"
     },
@@ -9210,7 +9338,7 @@
           "type": "integer"
         },
         "targetItemId": {
-          "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
+          "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - stdin reviews, which refer to the existing parent command item and have a separate approval ID in the action payload - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
           "type": [
             "string",
             "null"
@@ -9256,7 +9384,7 @@
           "type": "integer"
         },
         "targetItemId": {
-          "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
+          "description": "Identifier for the reviewed item or tool call when one exists.\n\nIn most cases, one review maps to one target item. The exceptions are - execve reviews, where a single command may contain multiple execve calls to review (only possible when using the shell_zsh_fork feature) - stdin reviews, which refer to the existing parent command item and have a separate approval ID in the action payload - network policy reviews, where there is no target item\n\nA network call is triggered by a CommandExecution item, so having a target_item_id set to the CommandExecution item would be misleading because the review is about the network call, not the command execution. Therefore, target_item_id is set to None for network policy reviews.",
           "type": [
             "string",
             "null"
@@ -9567,6 +9695,41 @@
           ],
           "title": "AmazonBedrockv2::LoginAccountParams",
           "type": "object"
+        },
+        {
+          "description": "[UNSTABLE] Managed Amazon Bedrock AWS access key login is experimental.",
+          "properties": {
+            "accessKeyId": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "secretAccessKey": {
+              "type": "string"
+            },
+            "sessionToken": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "amazonBedrockAccessKeys"
+              ],
+              "title": "AmazonBedrockAccessKeysv2::LoginAccountParamsType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "accessKeyId",
+            "region",
+            "secretAccessKey",
+            "type"
+          ],
+          "title": "AmazonBedrockAccessKeysv2::LoginAccountParams",
+          "type": "object"
         }
       ],
       "title": "LoginAccountParams"
@@ -9694,6 +9857,13 @@
     },
     "ManagedHooksRequirements": {
       "properties": {
+        "Interrupt": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
         "PermissionRequest": {
           "items": {
             "$ref": "#/definitions/ConfiguredHookMatcherGroup"
@@ -16386,6 +16556,66 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/realtime/item/started"
+              ],
+              "title": "Thread/realtime/item/startedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadRealtimeItemStartedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/startedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/realtime/item/transcript/delta"
+              ],
+              "title": "Thread/realtime/item/transcript/deltaNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadRealtimeItemTranscriptDeltaNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/transcript/deltaNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/realtime/item/completed"
+              ],
+              "title": "Thread/realtime/item/completedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadRealtimeItemCompletedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/realtime/item/completedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/realtime/transcript/delta"
               ],
               "title": "Thread/realtime/transcript/deltaNotificationMethod",
@@ -16805,6 +17035,13 @@
         "path": {
           "$ref": "#/definitions/AbsolutePathBuf"
         },
+        "pluginId": {
+          "description": "Owning plugin ID, matching `PluginSummary.id`, when known.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "scope": {
           "$ref": "#/definitions/SkillScope"
         },
@@ -17118,7 +17355,8 @@
       "enum": [
         "started",
         "interacted",
-        "interrupted"
+        "interrupted",
+        "completed"
       ],
       "type": "string"
     },
@@ -17351,6 +17589,15 @@
             }
           ],
           "description": "Optional Git metadata captured when the thread was created."
+        },
+        "historyMode": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ThreadHistoryMode"
+            }
+          ],
+          "default": "legacy",
+          "description": "Persisted thread history contract selected when this thread was created."
         },
         "id": {
           "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
@@ -17659,6 +17906,10 @@
           ]
         },
         "ephemeral": {
+          "type": "boolean"
+        },
+        "excludeTurns": {
+          "description": "When true, return only thread metadata and live fork state without populating `thread.turns`. This is useful when the client plans to call `thread/turns/list` immediately after forking. Full-history hydration is deprecated for paginated threads; use this with `thread/turns/list` and `thread/items/list` instead.",
           "type": "boolean"
         },
         "lastTurnId": {
@@ -18839,6 +19090,83 @@
       ],
       "type": "object"
     },
+    "ThreadItemsListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "cursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Optional item page size.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sortDirection": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortDirection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional item pagination direction; defaults to ascending."
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "description": "Optional turn id to filter by. When omitted, returns items across the thread.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadItemsListParams",
+      "type": "object"
+    },
+    "ThreadItemsListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "backwardsCursor": {
+          "description": "Opaque cursor to pass as `cursor` when reversing `sortDirection`. This is only populated when the page contains at least one item.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "items": {
+            "$ref": "#/definitions/ThreadItemEntry"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. if None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "title": "ThreadItemsListResponse",
+      "type": "object"
+    },
     "ThreadListCwdFilter": {
       "anyOf": [
         {
@@ -19156,7 +19484,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "includeTurns": {
-          "description": "When true, include turns and their items from rollout history.",
+          "description": "When true, include turns and their items from rollout history. Full-history hydration is deprecated for paginated threads; prefer a metadata-only read and page with `thread/turns/list` and `thread/items/list`.",
           "type": "boolean"
         },
         "threadId": {
@@ -19220,6 +19548,65 @@
       ],
       "type": "object"
     },
+    "ThreadRealtimeBemItemPresentation": {
+      "description": "EXPERIMENTAL - how an existing agent item appears in a realtime conversation.",
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "wholeItem"
+              ],
+              "title": "WholeItemThreadRealtimeBemItemPresentationType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "WholeItemThreadRealtimeBemItemPresentation",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "inlineMarkdown"
+              ],
+              "title": "InlineMarkdownThreadRealtimeBemItemPresentationType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "InlineMarkdownThreadRealtimeBemItemPresentation",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "index": {
+              "format": "uint32",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "type": {
+              "enum": [
+                "inlineVisualization"
+              ],
+              "title": "InlineVisualizationThreadRealtimeBemItemPresentationType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "index",
+            "type"
+          ],
+          "title": "InlineVisualizationThreadRealtimeBemItemPresentation",
+          "type": "object"
+        }
+      ]
+    },
     "ThreadRealtimeClosedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "EXPERIMENTAL - emitted when thread realtime transport closes.",
@@ -19274,6 +19661,112 @@
       ],
       "type": "object"
     },
+    "ThreadRealtimeItem": {
+      "description": "EXPERIMENTAL - a thread-scoped realtime item in the canonical timeline.",
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "realtimeSessionStarted"
+              ],
+              "title": "RealtimeSessionStartedThreadRealtimeItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "RealtimeSessionStartedThreadRealtimeItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "role": {
+              "$ref": "#/definitions/ThreadRealtimeTranscriptRole"
+            },
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "transcriptSegment"
+              ],
+              "title": "TranscriptSegmentThreadRealtimeItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "role",
+            "text",
+            "type"
+          ],
+          "title": "TranscriptSegmentThreadRealtimeItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "item_id": {
+              "type": "string"
+            },
+            "presentation": {
+              "$ref": "#/definitions/ThreadRealtimeBemItemPresentation"
+            },
+            "turn_id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "bemItemPromoted"
+              ],
+              "title": "BemItemPromotedThreadRealtimeItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "item_id",
+            "presentation",
+            "turn_id",
+            "type"
+          ],
+          "title": "BemItemPromotedThreadRealtimeItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "outcome": {
+              "$ref": "#/definitions/ThreadRealtimeSessionOutcome"
+            },
+            "type": {
+              "enum": [
+                "realtimeSessionClosed"
+              ],
+              "title": "RealtimeSessionClosedThreadRealtimeItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "outcome",
+            "type"
+          ],
+          "title": "RealtimeSessionClosedThreadRealtimeItem",
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "realtimeSessionId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "realtimeSessionId"
+      ],
+      "type": "object"
+    },
     "ThreadRealtimeItemAddedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.",
@@ -19288,6 +19781,64 @@
         "threadId"
       ],
       "title": "ThreadRealtimeItemAddedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeItemCompletedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - a realtime timeline item published after canonical commit.",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/ThreadRealtimeItem"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeItemCompletedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeItemStartedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - a realtime timeline item started before its content streams.",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/ThreadRealtimeItem"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeItemStartedNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeItemTranscriptDeltaNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - text appended to an active realtime transcript item.",
+      "properties": {
+        "delta": {
+          "type": "string"
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "delta",
+        "itemId",
+        "threadId"
+      ],
+      "title": "ThreadRealtimeItemTranscriptDeltaNotification",
       "type": "object"
     },
     "ThreadRealtimeOutputAudioDeltaNotification": {
@@ -19325,6 +19876,13 @@
       ],
       "title": "ThreadRealtimeSdpNotification",
       "type": "object"
+    },
+    "ThreadRealtimeSessionOutcome": {
+      "enum": [
+        "ended",
+        "failed"
+      ],
+      "type": "string"
     },
     "ThreadRealtimeStartTransport": {
       "description": "EXPERIMENTAL - transport used by thread realtime.",
@@ -19459,6 +20017,13 @@
       "title": "ThreadRealtimeTranscriptDoneNotification",
       "type": "object"
     },
+    "ThreadRealtimeTranscriptRole": {
+      "enum": [
+        "user",
+        "assistant"
+      ],
+      "type": "string"
+    },
     "ThreadResumeInitialTurnsPageParams": {
       "properties": {
         "itemsView": {
@@ -19545,6 +20110,10 @@
             "null"
           ]
         },
+        "excludeTurns": {
+          "description": "When true, return only thread metadata and live-resume state without populating `thread.turns`. This is useful when the client plans to call `thread/turns/list` immediately after resuming. Full-history hydration is deprecated for paginated threads; use this with `thread/turns/list` and `thread/items/list` instead.",
+          "type": "boolean"
+        },
         "model": {
           "description": "Configuration overrides for the resumed thread, if any.",
           "type": [
@@ -19619,6 +20188,14 @@
           },
           "type": "array"
         },
+        "itemsBackwardsCursor": {
+          "default": null,
+          "description": "Opaque cursor for hydrating paginated items backwards.\n\nPass this as `cursor` to `thread/items/list` with `sortDirection: \"desc\"`. The first page includes the item identified by the cursor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "model": {
           "type": "string"
         },
@@ -19651,6 +20228,14 @@
         },
         "thread": {
           "$ref": "#/definitions/Thread"
+        },
+        "turnsBackwardsCursor": {
+          "default": null,
+          "description": "Opaque cursor for hydrating paginated turns backwards.\n\nPass this as `cursor` to `thread/turns/list` with `sortDirection: \"desc\"`. The first page includes the turn identified by the cursor.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -19663,6 +20248,57 @@
         "thread"
       ],
       "title": "ThreadResumeResponse",
+      "type": "object"
+    },
+    "ThreadRevertParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Replace a paginated thread's durable history with the prefix before one turn.\n\nThis only changes persisted conversation history. It does not revert local file changes.",
+      "properties": {
+        "beforeTurnId": {
+          "description": "Turn excluded from the replacement history, together with every later turn.",
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "beforeTurnId",
+        "threadId"
+      ],
+      "title": "ThreadRevertParams",
+      "type": "object"
+    },
+    "ThreadRevertResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "itemsBackwardsCursor": {
+          "description": "Opaque cursor for hydrating paginated items backwards.\n\nPass this as `cursor` to `thread/items/list` with `sortDirection: \"desc\"`. The first page includes the item identified by the cursor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "thread": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Thread"
+            }
+          ],
+          "description": "Updated loaded thread metadata. `turns` is always empty; hydrate retained history through `thread/turns/list`."
+        },
+        "turnsBackwardsCursor": {
+          "description": "Opaque cursor for hydrating paginated turns backwards.\n\nPass this as `cursor` to `thread/turns/list` with `sortDirection: \"desc\"`. The first page includes the turn identified by the cursor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "thread"
+      ],
+      "title": "ThreadRevertResponse",
       "type": "object"
     },
     "ThreadRevertedNotification": {
@@ -20454,6 +21090,161 @@
       "title": "ThreadStatusChangedNotification",
       "type": "object"
     },
+    "ThreadTimelineEntry": {
+      "description": "EXPERIMENTAL - one item or turn boundary in canonical rollout order.",
+      "oneOf": [
+        {
+          "properties": {
+            "item": {
+              "$ref": "#/definitions/ThreadItem"
+            },
+            "position": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "turnId": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "item"
+              ],
+              "title": "ItemThreadTimelineEntryType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "item",
+            "position",
+            "turnId",
+            "type"
+          ],
+          "title": "ItemThreadTimelineEntry",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "item": {
+              "$ref": "#/definitions/ThreadRealtimeItem"
+            },
+            "position": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "type": {
+              "enum": [
+                "realtime"
+              ],
+              "title": "RealtimeThreadTimelineEntryType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "item",
+            "position",
+            "type"
+          ],
+          "title": "RealtimeThreadTimelineEntry",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "position": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "started_at": {
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "turn_id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "turnStarted"
+              ],
+              "title": "TurnStartedThreadTimelineEntryType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "position",
+            "turn_id",
+            "type"
+          ],
+          "title": "TurnStartedThreadTimelineEntry",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "completed_at": {
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "duration_ms": {
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TurnError"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "position": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "started_at": {
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status": {
+              "$ref": "#/definitions/TurnStatus"
+            },
+            "turn_id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "turnCompleted"
+              ],
+              "title": "TurnCompletedThreadTimelineEntryType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "position",
+            "status",
+            "turn_id",
+            "type"
+          ],
+          "title": "TurnCompletedThreadTimelineEntry",
+          "type": "object"
+        }
+      ]
+    },
     "ThreadTokenUsage": {
       "properties": {
         "last": {
@@ -20495,6 +21286,87 @@
         "turnId"
       ],
       "title": "ThreadTokenUsageUpdatedNotification",
+      "type": "object"
+    },
+    "ThreadTurnsListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "cursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemsView": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TurnItemsView"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How much item detail to include for each returned turn; defaults to summary."
+        },
+        "limit": {
+          "description": "Optional turn page size.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sortDirection": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortDirection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional turn pagination direction; defaults to descending."
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadTurnsListParams",
+      "type": "object"
+    },
+    "ThreadTurnsListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "backwardsCursor": {
+          "description": "Opaque cursor to pass as `cursor` when reversing `sortDirection`. This is only populated when the page contains at least one turn. Use it with the opposite `sortDirection` to include the anchor turn again and catch updates to that turn.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "items": {
+            "$ref": "#/definitions/Turn"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last turn. if None, there are no more turns to return.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "title": "ThreadTurnsListResponse",
       "type": "object"
     },
     "ThreadUnarchiveParams": {
@@ -21126,6 +21998,13 @@
             "null"
           ]
         },
+        "serviceTierForTurn": {
+          "description": "Override the service tier only when this request starts a new turn. Use \"default\" for standard speed. Omitted or null inherits the thread's tier. Does not change the thread's tier or a turn being steered.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "summary": {
           "anyOf": [
             {
@@ -21139,6 +22018,13 @@
         },
         "threadId": {
           "type": "string"
+        },
+        "turnTrigger": {
+          "description": "Optional source classification for the caller that starts this turn. Ignored when this request steers an already-active turn.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -113,7 +113,9 @@ async fn thread_fork(reporter: &Reporter) {
                 personality: None,
                 sandbox_policy: None,
                 service_tier: None,
+                service_tier_for_turn: None,
                 summary: None,
+                turn_trigger: None,
             })
             .await
             .map_err(|e| e.to_string())?;
@@ -264,7 +266,9 @@ async fn live_turn(reporter: &Reporter) {
                 personality: None,
                 sandbox_policy: None,
                 service_tier: None,
+                service_tier_for_turn: None,
                 summary: None,
+                turn_trigger: None,
             })
             .await
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Fixes #332 — dedicated drift-only PR, same pattern as #329/#331. Snapshots are byte-identical copies of upstream `openai/codex@main`; `scripts/check_codex_schema_drift.py` exits 0.

## Upstream drift mirrored (0.148-era)

**New experimental realtime-item timeline surface**
- Notifications `thread/realtime/item/started`, `thread/realtime/item/completed`, `thread/realtime/item/transcript/delta` — typed structs, wired through all `Notification` dispatch sites, method constants, and the live-audit arm.
- `ThreadRealtimeItem` (session-started / transcript-segment / bem-item-promoted / session-closed) with `ThreadRealtimeBemItemPresentation`, `ThreadRealtimeSessionOutcome`, `ThreadRealtimeTranscriptRole`. Wire casing quirk mirrored exactly: top-level `realtimeSessionId` is camelCase while variant payload fields (`item_id`, `turn_id`) are snake_case.
- `ThreadTimelineEntry` (item / realtime / turnStarted / turnCompleted), same mixed-casing quirk noted in a doc comment.

**Paginated thread history**
- New RPCs `thread/items/list`, `thread/turns/list`, `thread/revert` with typed params/responses (`ThreadItemEntry` newly modeled) and `AsyncClient::{thread_items_list, thread_turns_list, thread_revert}` helpers.
- `excludeTurns` on `ThreadForkParams`/`ThreadResumeParams`; `itemsBackwardsCursor`/`turnsBackwardsCursor` on `ThreadResumeResponse`; `Thread.historyMode` (new `ThreadHistoryMode`, tolerant `Option` for pre-0.148 servers); `ThreadReadParams` hydration-deprecation is doc-only upstream.

**Smaller adds**
- `AuthMode::BedrockAccessKeys` + `LoginAccountParams::AmazonBedrockAccessKeys`
- `CodexErrorInfo::RateLimitExceeded`
- `CollabAgentTool::{SendMessage, FollowupTask, InterruptAgent, ListAgents}`, `CollabAgentToolCallStatus::Interrupted`, `SubAgentActivityKind::Completed`
- `HookEventName::Interrupt` (ManagedHooksRequirements itself remains unmodeled)
- `GuardianApprovalReviewAction::WriteStdin` (child approval for stdin to a running command)
- v1: new `CommandExecutionApprovalKind` enum + optional `kind` on `CommandExecutionRequestApprovalParams`
- `SkillMetadata.pluginId`, `TurnStartParams.{serviceTierForTurn, turnTrigger}`, `CyberAccessProgram` enum

Exhaustive `TurnStartParams` literals in examples/tests/wirecheck gained the two new `None` fields.

## Versioning
`0.147.3 → 0.147.4` (crate-side patch; tested pin stays Codex CLI `0.147.0`, README bullet now "tested CLI + 4 crate-side patches"). CHANGELOG updated.

## Verification
- `python3 scripts/check_codex_schema_drift.py` → both snapshots byte-identical to upstream
- `cargo fmt` / `cargo clippy --all-targets --all-features -D warnings` / `cargo test --workspace` (25 suites) all green
- Live: `wirecheck run codex` against installed codex-cli **0.148.0** — all 5 checks pass (binary, auth, live_turn with 15 typed notifications, thread_fork, account_reads)