### PR TITLE
codex-codes 0.147.5: resnapshot vs openai/codex@main (fixes #334)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.4"
+version = "0.147.5"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.4` (tested CLI + 4 crate-side patches), tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.147.5` (tested CLI + 5 crate-side patches), tested against Codex CLI `0.147.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.147.5] - 2026-08-28
+
+### Added
+
+- Resnapshot vs `openai/codex@main` (fixes #334): the misalignment-block
+  continuation surface — `TurnError.misalignment` with
+  `MisalignmentErrorDetails` (public explanation, open-ended `errorType`,
+  and a `MisalignmentSteer` instruction to submit as the next turn's input);
+  typed `modelProvider/authRecoveryStarted` / `authRecoveryCompleted`
+  notifications (`AuthRecoveryNotification`); tool-output injection on
+  turn start (`TurnStartParams.toolOutput` → `TurnToolOutput` with
+  `FunctionCallOutputBody` / `FunctionCallOutputContentItem`, newly
+  modeled) and the matching `ThreadItem::FunctionCallOutput` variant;
+  `Project.recencyAt` + `ProjectSortKey`;
+  `ThreadShellCommandParams.timeoutMs`; and `ResponseUsageMetadata`.
+
 ## [0.147.4] - 2026-08-26
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.4"
+version = "0.147.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/async_client.rs
+++ b/codex-codes/examples/async_client.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "What is the capital of France?".to_string(),
                 text_elements: None,

--- a/codex-codes/examples/basic_repl.rs
+++ b/codex-codes/examples/basic_repl.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client
             .turn_start(&TurnStartParams {
                 thread_id: thread_id.clone(),
+                tool_output: None,
                 input: vec![UserInput::Text {
                     text: input.to_string(),
                     text_elements: None,

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -599,6 +599,7 @@ mod samples {
                     message: "something blew up".into(),
                     additional_details: None,
                     codex_error_info: None,
+                    misalignment: None,
                 },
                 thread_id: "th_abc".into(),
                 turn_id: "tn_xyz".into(),

--- a/codex-codes/examples/sync_client.rs
+++ b/codex-codes/examples/sync_client.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("\nSending query: What is the capital of France?\n");
     client.turn_start(&TurnStartParams {
         thread_id: thread.thread.id.clone(),
+        tool_output: None,
         input: vec![UserInput::Text {
             text: "What is the capital of France?".to_string(),
             text_elements: None,

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -28,9 +28,10 @@ use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, Reques
 use crate::protocol::{
     methods, AccountLoginCompletedNotification, AccountRateLimitsUpdatedNotification,
     AccountUpdatedNotification, AgentMessageDeltaNotification, AppListUpdatedNotification,
-    CommandExecOutputDeltaNotification, CommandExecutionOutputDeltaNotification,
-    CommandExecutionRequestApprovalParams, ConfigWarningNotification, ContextCompactedNotification,
-    DeprecationNoticeNotification, EnvironmentConnectionNotification, ErrorNotification,
+    AuthRecoveryNotification, CommandExecOutputDeltaNotification,
+    CommandExecutionOutputDeltaNotification, CommandExecutionRequestApprovalParams,
+    ConfigWarningNotification, ContextCompactedNotification, DeprecationNoticeNotification,
+    EnvironmentConnectionNotification, ErrorNotification,
     ExternalAgentConfigImportCompletedNotification, ExternalAgentConfigImportProgressNotification,
     FileChangeOutputDeltaNotification, FileChangePatchUpdatedNotification,
     FileChangeRequestApprovalParams, FsChangedNotification,
@@ -229,6 +230,10 @@ pub enum Notification {
     ThreadRealtimeItemCompleted(ThreadRealtimeItemCompletedNotification),
     /// `thread/realtime/item/transcript/delta` (0.148 upstream, experimental)
     ThreadRealtimeItemTranscriptDelta(ThreadRealtimeItemTranscriptDeltaNotification),
+    /// `modelProvider/authRecoveryStarted` (0.148 upstream)
+    ModelProviderAuthRecoveryStarted(AuthRecoveryNotification),
+    /// `modelProvider/authRecoveryCompleted` (0.148 upstream)
+    ModelProviderAuthRecoveryCompleted(AuthRecoveryNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -253,6 +258,12 @@ impl Notification {
             Self::ThreadRealtimeItemCompleted(_) => methods::THREAD_REALTIME_ITEM_COMPLETED,
             Self::ThreadRealtimeItemTranscriptDelta(_) => {
                 methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA
+            }
+            Self::ModelProviderAuthRecoveryStarted(_) => {
+                methods::MODEL_PROVIDER_AUTH_RECOVERY_STARTED
+            }
+            Self::ModelProviderAuthRecoveryCompleted(_) => {
+                methods::MODEL_PROVIDER_AUTH_RECOVERY_COMPLETED
             }
             Self::ThreadStatusChanged(_) => methods::THREAD_STATUS_CHANGED,
             Self::ThreadTokenUsageUpdated(_) => methods::THREAD_TOKEN_USAGE_UPDATED,
@@ -435,6 +446,12 @@ impl Notification {
             }
             methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA => {
                 serde_json::from_value(params_value).map(Self::ThreadRealtimeItemTranscriptDelta)
+            }
+            methods::MODEL_PROVIDER_AUTH_RECOVERY_STARTED => {
+                serde_json::from_value(params_value).map(Self::ModelProviderAuthRecoveryStarted)
+            }
+            methods::MODEL_PROVIDER_AUTH_RECOVERY_COMPLETED => {
+                serde_json::from_value(params_value).map(Self::ModelProviderAuthRecoveryCompleted)
             }
             methods::THREAD_STATUS_CHANGED => {
                 serde_json::from_value(params_value).map(Self::ThreadStatusChanged)
@@ -656,6 +673,12 @@ impl Notification {
             }
             Self::ThreadRealtimeItemTranscriptDelta(v) => {
                 pack(methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA, v)
+            }
+            Self::ModelProviderAuthRecoveryStarted(v) => {
+                pack(methods::MODEL_PROVIDER_AUTH_RECOVERY_STARTED, v)
+            }
+            Self::ModelProviderAuthRecoveryCompleted(v) => {
+                pack(methods::MODEL_PROVIDER_AUTH_RECOVERY_COMPLETED, v)
             }
             Self::ThreadStatusChanged(v) => pack(methods::THREAD_STATUS_CHANGED, v),
             Self::ThreadTokenUsageUpdated(v) => pack(methods::THREAD_TOKEN_USAGE_UPDATED, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -202,6 +202,8 @@ pub mod methods {
     pub const THREAD_REALTIME_ITEM_STARTED: &str = "thread/realtime/item/started";
     pub const THREAD_REALTIME_ITEM_COMPLETED: &str = "thread/realtime/item/completed";
     pub const THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA: &str = "thread/realtime/item/transcript/delta";
+    pub const MODEL_PROVIDER_AUTH_RECOVERY_STARTED: &str = "modelProvider/authRecoveryStarted";
+    pub const MODEL_PROVIDER_AUTH_RECOVERY_COMPLETED: &str = "modelProvider/authRecoveryCompleted";
     pub const WINDOWS_WORLD_WRITABLE_WARNING: &str = "windows/worldWritableWarning";
     pub const WINDOWS_SANDBOX_SETUP_COMPLETED: &str = "windowsSandbox/setupCompleted";
     pub const THREAD_SETTINGS_UPDATED: &str = "thread/settings/updated";

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -582,6 +582,22 @@ pub struct AttestationGenerateResponse {
     pub token: String,
 }
 
+/// `modelProvider/authRecoveryStarted` / `modelProvider/authRecoveryCompleted`
+/// params — the server is re-establishing a model provider's credentials
+/// mid-turn (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthRecoveryNotification {
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub provider: String,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    #[serde(rename = "turnId", default)]
+    pub turn_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum AuthMode {
     #[serde(rename = "apikey")]
@@ -2574,6 +2590,35 @@ pub struct FuzzyFileSearchResponse {
     pub files: Vec<FuzzyFileSearchResult>,
 }
 
+/// A tool call's output body: either a plain string or Responses-API
+/// compatible content items (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FunctionCallOutputBody {
+    Text(String),
+    Items(Vec<FunctionCallOutputContentItem>),
+}
+
+/// Responses-API compatible content items a tool call can return — the
+/// subset of ContentItem supported as function call outputs (0.148 upstream).
+/// Wire tags and fields are snake_case, unlike most v2 types.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum FunctionCallOutputContentItem {
+    #[serde(rename = "input_text")]
+    InputText { text: String },
+    #[serde(rename = "input_image")]
+    InputImage {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<ImageDetail>,
+        image_url: String,
+    },
+    #[serde(rename = "input_audio")]
+    InputAudio { audio_url: String },
+    #[serde(rename = "encrypted_content")]
+    EncryptedContent { encrypted_content: String },
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FuzzyFileSearchResult {
@@ -4306,6 +4351,34 @@ pub struct MigrationDetails {
     pub subagents: Option<Vec<SubagentMigration>>,
 }
 
+/// Public explanation and continuation instruction attached to a
+/// misalignment-blocked turn error (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MisalignmentErrorDetails {
+    #[serde(
+        rename = "detailedExplanation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub detailed_explanation: Option<String>,
+    /// Open-ended classification; accept categories added upstream.
+    #[serde(rename = "errorType", default, skip_serializing_if = "Option::is_none")]
+    pub error_type: Option<String>,
+    /// Instruction to submit as the next turn's user input if continuation
+    /// is confirmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steer: Option<MisalignmentSteer>,
+}
+
+/// The steering instruction inside [`MisalignmentErrorDetails`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MisalignmentSteer {
+    #[serde(default)]
+    pub message: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ModeKind {
     #[serde(rename = "plan")]
@@ -5881,6 +5954,14 @@ pub struct ResourceTemplate {
     pub uri_template: String,
 }
 
+/// Usage metadata reported for one upstream response (0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseUsageMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ReviewDecision {
     #[serde(rename = "approved")]
@@ -5985,10 +6066,23 @@ pub struct Project {
     pub name: String,
     #[serde(default)]
     pub position: i64,
+    /// Newest non-archived member thread's recency, in Unix seconds;
+    /// absent/null when none exist (0.148 upstream).
+    #[serde(rename = "recencyAt", default, skip_serializing_if = "Option::is_none")]
+    pub recency_at: Option<i64>,
     #[serde(default)]
     pub roots: Vec<ProjectRoot>,
     #[serde(rename = "updatedAt", default)]
     pub updated_at: i64,
+}
+
+/// Sort order for project listings (0.148 upstream).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProjectSortKey {
+    #[serde(rename = "position")]
+    Position,
+    #[serde(rename = "recencyAt")]
+    RecencyAt,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -7406,6 +7500,14 @@ pub enum ThreadItem {
     ContextCompaction {
         id: String,
     },
+    #[serde(rename = "functionCallOutput")]
+    FunctionCallOutput {
+        id: String,
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+        output: FunctionCallOutputBody,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -8168,6 +8270,10 @@ pub struct ThreadShellCommandParams {
     pub command: String,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+    /// Maximum execution time in ms; defaults to one hour when omitted.
+    /// Zero requests an immediate timeout, not unlimited (0.148 upstream).
+    #[serde(rename = "timeoutMs", default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -8694,6 +8800,10 @@ pub struct TurnError {
     pub codex_error_info: Option<CodexErrorInfo>,
     #[serde(default)]
     pub message: String,
+    /// Public explanation and continuation instruction for a misalignment
+    /// block (0.148 upstream).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub misalignment: Option<MisalignmentErrorDetails>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -8826,6 +8936,14 @@ pub struct TurnStartParams {
     pub summary: Option<ReasoningSummary>,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+    /// Pre-computed tool output to inject when starting the turn
+    /// (0.148 upstream).
+    #[serde(
+        rename = "toolOutput",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tool_output: Option<TurnToolOutput>,
     /// Optional source classification for the caller starting this turn;
     /// ignored when steering an already-active turn (0.148 upstream).
     #[serde(
@@ -8862,6 +8980,19 @@ pub enum TurnStatus {
     Failed,
     #[serde(rename = "inProgress")]
     InProgress,
+}
+
+/// A pre-computed tool output supplied when starting a turn
+/// (`TurnStartParams.toolOutput`, 0.148 upstream).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnToolOutput {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde()]
+    pub output: FunctionCallOutputBody,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -59,6 +59,7 @@ async fn test_async_client_thread_fork() {
     client
         .turn_start(&TurnStartParams {
             thread_id: source.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "Reply with just OK.".to_string(),
                 text_elements: None,
@@ -135,6 +136,7 @@ async fn test_async_client_basic_turn() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "What is 2 + 2? Reply with just the number.".to_string(),
                 text_elements: None,
@@ -265,6 +267,7 @@ fn test_sync_client_basic_turn() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "What is 2 + 2? Reply with just the number.".to_string(),
                 text_elements: None,
@@ -333,6 +336,7 @@ async fn test_async_client_multi_turn() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "Remember the number 42. Just say OK.".to_string(),
                 text_elements: None,
@@ -377,6 +381,7 @@ async fn test_async_client_multi_turn() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "What number did I ask you to remember? Reply with just the number."
                     .to_string(),
@@ -445,6 +450,7 @@ async fn test_async_client_event_stream() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "Say hello.".to_string(),
                 text_elements: None,
@@ -523,6 +529,7 @@ async fn test_typed_message_audit_strict() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "Run `ls` in the current directory, then briefly describe what you saw."
                     .to_string(),
@@ -653,6 +660,12 @@ async fn test_typed_message_audit_strict() {
                     Notification::ThreadRealtimeItemTranscriptDelta(_) => {
                         "ThreadRealtimeItemTranscriptDelta"
                     }
+                    Notification::ModelProviderAuthRecoveryStarted(_) => {
+                        "ModelProviderAuthRecoveryStarted"
+                    }
+                    Notification::ModelProviderAuthRecoveryCompleted(_) => {
+                        "ModelProviderAuthRecoveryCompleted"
+                    }
                     Notification::WindowsWorldWritableWarning(_) => "WindowsWorldWritableWarning",
                     Notification::WindowsSandboxSetupCompleted(_) => "WindowsSandboxSetupCompleted",
                     Notification::Unknown { method, .. } => {
@@ -777,6 +790,7 @@ async fn test_async_client_writes_compilable_quicksort() {
     client
         .turn_start(&TurnStartParams {
             thread_id: thread.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: prompt.to_string(),
                 text_elements: None,
@@ -960,6 +974,7 @@ async fn test_thread_resume_reopens_thread_via_typed_helper() {
     client
         .turn_start(&TurnStartParams {
             thread_id: source.thread.id.clone(),
+            tool_output: None,
             input: vec![UserInput::Text {
                 text: "Remember the word 'garnet'. Reply with just OK.".to_string(),
                 text_elements: None,

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -5576,6 +5576,46 @@
           "properties": {
             "method": {
               "enum": [
+                "modelProvider/authRecoveryStarted"
+              ],
+              "title": "ModelProvider/authRecoveryStartedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/AuthRecoveryNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "ModelProvider/authRecoveryStartedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "modelProvider/authRecoveryCompleted"
+              ],
+              "title": "ModelProvider/authRecoveryCompletedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/AuthRecoveryNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "ModelProvider/authRecoveryCompletedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "turn/moderationMetadata"
               ],
               "title": "Turn/moderationMetadataNotificationMethod",
@@ -7668,6 +7708,31 @@
             "type": "string"
           }
         ]
+      },
+      "AuthRecoveryNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "turnId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "provider",
+          "threadId",
+          "turnId"
+        ],
+        "title": "AuthRecoveryNotification",
+        "type": "object"
       },
       "AutoCompactTokenLimitScope": {
         "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
@@ -14654,6 +14719,47 @@
         },
         "type": "object"
       },
+      "MisalignmentErrorDetails": {
+        "properties": {
+          "detailedExplanation": {
+            "description": "A substantive localized explanation is required before offering continuation.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "errorType": {
+            "description": "Open-ended classification; clients must accept categories added by Responses.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "steer": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/MisalignmentSteer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Instruction to submit as the next turn's user input if continuation is confirmed."
+          }
+        },
+        "type": "object"
+      },
+      "MisalignmentSteer": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
       "ModeKind": {
         "description": "Initial collaboration mode to use when the TUI starts.",
         "enum": [
@@ -16904,6 +17010,14 @@
             "format": "int64",
             "type": "integer"
           },
+          "recencyAt": {
+            "description": "Newest non-archived member thread's recency, in Unix seconds; null when none exist.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "roots": {
             "items": {
               "$ref": "#/definitions/v2/ProjectRoot"
@@ -16961,6 +17075,13 @@
           "path"
         ],
         "type": "object"
+      },
+      "ProjectSortKey": {
+        "enum": [
+          "position",
+          "recencyAt"
+        ],
+        "type": "string"
       },
       "QueuedSubmission": {
         "properties": {
@@ -17207,6 +17328,16 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/v2/TokenUsageBreakdown"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "usageMetadata": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ResponseUsageMetadata"
               },
               {
                 "type": "null"
@@ -18459,6 +18590,18 @@
             "type": "object"
           }
         ]
+      },
+      "ResponseUsageMetadata": {
+        "description": "Usage metadata reported for one upstream response.",
+        "properties": {
+          "amount": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "ResponsesApiWebSearchAction": {
         "oneOf": [
@@ -20654,6 +20797,40 @@
               "type"
             ],
             "title": "AgentMessageThreadItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/v2/FunctionCallOutputBody"
+              },
+              "type": {
+                "enum": [
+                  "functionCallOutput"
+                ],
+                "title": "FunctionCallOutputThreadItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "output",
+              "type"
+            ],
+            "title": "FunctionCallOutputThreadItem",
             "type": "object"
           },
           {
@@ -23007,6 +23184,14 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "timeoutMs": {
+            "description": "Maximum execution time in milliseconds. Defaults to one hour when omitted or null. Must be non-negative; zero requests an immediate timeout, not unlimited execution. Does not affect the immediate RPC acknowledgement.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "required": [
@@ -24043,6 +24228,18 @@
           },
           "message": {
             "type": "string"
+          },
+          "misalignment": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/MisalignmentErrorDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional public explanation and continuation instruction for a misalignment block."
           }
         },
         "required": [
@@ -24284,6 +24481,16 @@
           "threadId": {
             "type": "string"
           },
+          "toolOutput": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/TurnToolOutput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "turnTrigger": {
             "description": "Optional source classification for the caller that starts this turn. Ignored when this request steers an already-active turn.",
             "type": [
@@ -24380,6 +24587,27 @@
           "turnId"
         ],
         "title": "TurnSteerResponse",
+        "type": "object"
+      },
+      "TurnToolOutput": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/v2/FunctionCallOutputBody"
+          }
+        },
+        "required": [
+          "name",
+          "output"
+        ],
         "type": "object"
       },
       "TurnsPage": {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -1245,6 +1245,31 @@
         }
       ]
     },
+    "AuthRecoveryNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "provider",
+        "threadId",
+        "turnId"
+      ],
+      "title": "AuthRecoveryNotification",
+      "type": "object"
+    },
     "AutoCompactTokenLimitScope": {
       "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
       "oneOf": [
@@ -10787,6 +10812,47 @@
       },
       "type": "object"
     },
+    "MisalignmentErrorDetails": {
+      "properties": {
+        "detailedExplanation": {
+          "description": "A substantive localized explanation is required before offering continuation.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorType": {
+          "description": "Open-ended classification; clients must accept categories added by Responses.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "steer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MisalignmentSteer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Instruction to submit as the next turn's user input if continuation is confirmed."
+        }
+      },
+      "type": "object"
+    },
+    "MisalignmentSteer": {
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
     "ModeKind": {
       "description": "Initial collaboration mode to use when the TUI starts.",
       "enum": [
@@ -13037,6 +13103,14 @@
           "format": "int64",
           "type": "integer"
         },
+        "recencyAt": {
+          "description": "Newest non-archived member thread's recency, in Unix seconds; null when none exist.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "roots": {
           "items": {
             "$ref": "#/definitions/ProjectRoot"
@@ -13094,6 +13168,13 @@
         "path"
       ],
       "type": "object"
+    },
+    "ProjectSortKey": {
+      "enum": [
+        "position",
+        "recencyAt"
+      ],
+      "type": "string"
     },
     "QueuedSubmission": {
       "properties": {
@@ -13340,6 +13421,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/TokenUsageBreakdown"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "usageMetadata": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResponseUsageMetadata"
             },
             {
               "type": "null"
@@ -14592,6 +14683,18 @@
           "type": "object"
         }
       ]
+    },
+    "ResponseUsageMetadata": {
+      "description": "Usage metadata reported for one upstream response.",
+      "properties": {
+        "amount": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "ResponsesApiWebSearchAction": {
       "oneOf": [
@@ -16350,6 +16453,46 @@
             "params"
           ],
           "title": "Model/verificationNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "modelProvider/authRecoveryStarted"
+              ],
+              "title": "ModelProvider/authRecoveryStartedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/AuthRecoveryNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "ModelProvider/authRecoveryStartedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "modelProvider/authRecoveryCompleted"
+              ],
+              "title": "ModelProvider/authRecoveryCompletedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/AuthRecoveryNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "ModelProvider/authRecoveryCompletedNotification",
           "type": "object"
         },
         {
@@ -18389,6 +18532,40 @@
             "type"
           ],
           "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "output": {
+              "$ref": "#/definitions/FunctionCallOutputBody"
+            },
+            "type": {
+              "enum": [
+                "functionCallOutput"
+              ],
+              "title": "FunctionCallOutputThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "output",
+            "type"
+          ],
+          "title": "FunctionCallOutputThreadItem",
           "type": "object"
         },
         {
@@ -20742,6 +20919,14 @@
         },
         "threadId": {
           "type": "string"
+        },
+        "timeoutMs": {
+          "description": "Maximum execution time in milliseconds. Defaults to one hour when omitted or null. Must be non-negative; zero requests an immediate timeout, not unlimited execution. Does not affect the immediate RPC acknowledgement.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
@@ -21778,6 +21963,18 @@
         },
         "message": {
           "type": "string"
+        },
+        "misalignment": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MisalignmentErrorDetails"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional public explanation and continuation instruction for a misalignment block."
         }
       },
       "required": [
@@ -22019,6 +22216,16 @@
         "threadId": {
           "type": "string"
         },
+        "toolOutput": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TurnToolOutput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "turnTrigger": {
           "description": "Optional source classification for the caller that starts this turn. Ignored when this request steers an already-active turn.",
           "type": [
@@ -22115,6 +22322,27 @@
         "turnId"
       ],
       "title": "TurnSteerResponse",
+      "type": "object"
+    },
+    "TurnToolOutput": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output": {
+          "$ref": "#/definitions/FunctionCallOutputBody"
+        }
+      },
+      "required": [
+        "name",
+        "output"
+      ],
       "type": "object"
     },
     "TurnsPage": {

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -99,6 +99,7 @@ async fn thread_fork(reporter: &Reporter) {
         client
             .turn_start(&TurnStartParams {
                 thread_id: source.thread.id.clone(),
+                tool_output: None,
                 input: vec![UserInput::Text {
                     text: "Reply with just OK.".to_string(),
                     text_elements: None,
@@ -252,6 +253,7 @@ async fn live_turn(reporter: &Reporter) {
         client
             .turn_start(&TurnStartParams {
                 thread_id: thread.thread.id.clone(),
+                tool_output: None,
                 input: vec![UserInput::Text {
                     text: "What is 2 + 2? Reply with just the number.".to_string(),
                     text_elements: None,


### PR DESCRIPTION
Fixes #334 — dedicated drift-only PR, same pattern as #329/#331/#333. Snapshots are byte-identical upstream copies; `scripts/check_codex_schema_drift.py` exits 0.

## Upstream drift mirrored (0.148-era)

**Misalignment-block continuation**
- `TurnError.misalignment` → new `MisalignmentErrorDetails` (localized explanation, open-ended `errorType` clients must tolerate, and a `MisalignmentSteer { message }` instruction to submit as the next turn's user input if continuation is confirmed).

**Model-provider auth recovery**
- New notifications `modelProvider/authRecoveryStarted` / `modelProvider/authRecoveryCompleted`, both carrying a new `AuthRecoveryNotification { message, provider, threadId, turnId }` — wired through all `Notification` dispatch sites, method constants, and the live-audit arm.

**Tool-output injection on turn start**
- `TurnStartParams.toolOutput` → new `TurnToolOutput { name, namespace?, output }` with `FunctionCallOutputBody` (untagged string-or-items) and `FunctionCallOutputContentItem` (input_text / input_image / input_audio / encrypted_content — snake_case wire tags, newly modeled; the type existed in the snapshot but had no crate mirror).
- Matching new `ThreadItem::FunctionCallOutput` variant.

**Smaller adds**
- `Project.recencyAt` (newest non-archived member thread's recency) + `ProjectSortKey` enum
- `ThreadShellCommandParams.timeoutMs` (default 1h; zero = immediate timeout)
- `ResponseUsageMetadata` (referenced by the unmodeled `RawResponseCompletedNotification`)

Exhaustive `TurnStartParams` literals (examples/tests/wirecheck, 14 sites) gained `tool_output: None`; the `schema_coverage` `TurnError` literal gained `misalignment: None`.

## Versioning
`0.147.4 → 0.147.5` (crate-side patch; tested pin stays Codex CLI `0.147.0`, README bullet now "tested CLI + 5 crate-side patches"). CHANGELOG updated.

## Verification
- Drift script: both snapshots byte-identical to upstream
- `cargo fmt` / `cargo clippy --all-targets --all-features -D warnings` / `cargo test --workspace` (25 suites) all green
- Live: `wirecheck run codex` against installed codex-cli **0.148.0** — 5/5 checks pass (live turn streams 15 typed notifications to completion)