### PR TITLE
codex-codes 0.150.1: re-baseline tested pin to Codex CLI 0.150.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.147.5"
+version = "0.150.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.147.5` (tested CLI + 5 crate-side patches), tested against Codex CLI `0.147.0`.
+- **`codex-codes`** — currently `codex-codes 0.150.1`, tested against Codex CLI `0.150.1`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.150.1] - 2026-08-29
+
+### Changed
+
+- Re-baseline the tested pin: the full integration suite (19 capture-corpus
+  + 14 live app-server tests, including the strict typed-message audit)
+  passes against Codex CLI **0.150.1**. `version::tested_cli_version()`
+  and the README `Tested against:` lines move from 0.147.0 to 0.150.1;
+  per the version-means-tested convention the crate version jumps to
+  0.150.1 (no code changes beyond the pin — the wire surface was already
+  current as of 0.147.5's resnapshot).
+
 ## [0.147.5] - 2026-08-28
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.147.5"
+version = "0.150.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.147.0
+**Tested against:** Codex CLI 0.150.1
 
 ## Installation
 
@@ -215,7 +215,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.147.0
+**Tested against:** Codex CLI 0.150.1
 
 The crate version means **tested against**: it names the newest Codex CLI
 the live integration suite has passed against. If you're using a different

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.147.0";
+const TESTED_VERSION: &str = "0.150.1";
 
 /// The Codex CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention.


### PR DESCRIPTION
Re-baseline per the version-means-tested convention, approved by Matt.

The full codex integration suite — 19 capture-corpus tests + 14 live app-server tests, including `test_typed_message_audit_strict` (fails on any notification the crate can't decode) — passes against the installed **codex-cli 0.150.1**. That's the bar for moving the tested pin, so:

- `version::tested_cli_version()`: `0.147.0` → `0.150.1`
- `codex-codes/README.md` "Tested against:" lines (both) → 0.150.1
- Root README bullet: `codex-codes 0.150.1, tested against Codex CLI 0.150.1` (offset arithmetic drops out — crate version equals tested CLI again)
- Crate version: `0.147.5` → `0.150.1` + CHANGELOG entry

No code changes beyond the pin — the wire surface was already current as of 0.147.5's resnapshot (#334), and snapshots remain byte-identical to `openai/codex@main`.

## Verification
- `cargo fmt` / `cargo clippy --all-targets --all-features -D warnings` / `cargo test --workspace` (25 suites) green
- Live tier: `cargo test -p codex-codes --features integration-tests -- --test-threads=1` → 33/33 pass vs codex-cli 0.150.1
- CI version-consistency lockstep clauses (Cargo.toml ↔ version.rs const ↔ both READMEs) all satisfied