### PR TITLE
codex-codes 0.150.2: release train + test annotations (fixes #337)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.150.1"
+version = "0.150.2"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.150.1`, tested against Codex CLI `0.150.1`.
+- **`codex-codes`** — currently `codex-codes 0.150.2` (tested CLI + 1 crate-side patch), tested against Codex CLI `0.150.1`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,19 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.150.2] - 2026-08-31
+
+Wire-surface work in this release landed via #339 (thanks @marmeladema);
+this release also resnapshots vs `openai/codex@main` (fixes #337).
 
 ### Added
 
 - Synchronous helpers for turn steering, paginated thread history, and thread
   revert, matching the asynchronous client.
+- `GetAccountRateLimitsResponse.{accountId, rateLimitUpsell}` and the
+  `openaiForm` MCP elicitation request mode (`OpenAiElicitationForm`).
 
 ### Fixed
 
-- Preserve unknown properties in open config objects, including
-  `model_providers`, and distinguish modeled methods from sample coverage.
-- Include `accountId` and `rateLimitUpsell` in account rate-limit responses.
-- Accept the current `openaiForm` MCP elicitation request mode.
+- **Breaking**: `Config`, `AnalyticsConfig`, and `SandboxWorkspaceWrite` now
+  serialize with Codex's canonical snake_case wire field names (they mirror
+  config.toml, unlike the rest of app-server v2's camelCase). The previous
+  camelCase serialization silently decoded every field to its default on the
+  real wire.
+- Unknown properties on `Config`/`AnalyticsConfig` (which upstream marks
+  `additionalProperties: true`, e.g. `model_providers`) are preserved in
+  flatten maps instead of dropped.
 
 ## [0.150.1] - 2026-08-29
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.150.1"
+version = "0.150.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use codex_codes::{
     ThreadTurnsListResponse, TurnSteerResponse,
 };
 
+/// config/read round-trips snake_case wire fields and keeps unknown Config/AnalyticsConfig properties in the flatten maps.
 #[test]
 fn config_read_preserves_additional_properties() {
     let original = serde_json::json!({
@@ -58,6 +59,7 @@ fn config_read_preserves_additional_properties() {
     );
 }
 
+/// GetAccountRateLimitsResponse decodes accountId and the backend-owned rateLimitUpsell banner, round-tripping both.
 #[test]
 fn account_rate_limits_include_account_and_upsell() {
     let original = serde_json::json!({
@@ -82,6 +84,7 @@ fn account_rate_limits_include_account_and_upsell() {
     );
 }
 
+/// MCP elicitation requests with the newer camelCase "openaiForm" mode decode to the OpenAiElicitationForm arm.
 #[test]
 fn mcp_elicitation_accepts_current_openai_form_mode() {
     let request: McpServerElicitationRequestParams = serde_json::from_value(serde_json::json!({
@@ -97,6 +100,7 @@ fn mcp_elicitation_accepts_current_openai_form_mode() {
     ));
 }
 
+/// Response types behind the new sync helpers (turn/steer, items/turns list, thread/revert) decode minimal wire shapes.
 #[test]
 fn sync_helper_response_types_decode_current_wire_shapes() {
     let steer: TurnSteerResponse =


### PR DESCRIPTION
Reworked after #339 merged (which absorbed this PR's original wire-surface changes — rate-limits fields, openaiForm elicitation, snapshot refresh). This PR is now the release train on top:

- **Fix the CI break #339 introduced**: its four new tests in `integration_tests.rs` lacked the required `///` descriptions, failing the Check Test Annotations job on main. All 138 now annotated.
- Version `0.150.1 → 0.150.2` (crate-side patch; tested pin stays Codex CLI 0.150.1, README bullet updated to "+1 crate-side patch").
- CHANGELOG: fold #339's `[Unreleased]` section into a dated 0.150.2 entry crediting @marmeladema, spelling out the breaking snake_case Config serialization fix.
- Closes #337 (the openaiForm elicitation drift — shipped via #339's snapshot update, which is JSON-identical to upstream; the drift check now grades on JSON equality per #340).

Verification: fmt / clippy `-D warnings` / 25 workspace test suites green; annotation check ✅ 138/138.