### PR TITLE
Expand stable Codex protocol coverage

### DIFF
--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Synchronous helpers for turn steering, paginated thread history, and thread
+  revert, matching the asynchronous client.
+
+### Fixed
+
+- Preserve unknown properties in open config objects, including
+  `model_providers`, and distinguish modeled methods from sample coverage.
+- Include `accountId` and `rateLimitUpsell` in account rate-limit responses.
+- Accept the current `openaiForm` MCP elicitation request mode.
+
 ## [0.150.1] - 2026-08-29
 
 ### Changed

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -498,6 +498,9 @@ mod samples {
             methods::THREAD_LOADED_LIST,
             methods::THREAD_READ,
             methods::THREAD_INJECT_ITEMS,
+            methods::THREAD_ITEMS_LIST,
+            methods::THREAD_TURNS_LIST,
+            methods::THREAD_REVERT,
             methods::SKILLS_LIST,
             methods::HOOKS_LIST,
             methods::MARKETPLACE_ADD,
@@ -616,6 +619,30 @@ mod samples {
         for (method, sample) in codex_codes::protocol_generated::samples::client_request_samples() {
             m.insert(method, sample);
         }
+        m.insert(
+            methods::THREAD_ITEMS_LIST,
+            serde_json::to_value(codex_codes::ThreadItemsListParams {
+                thread_id: "thread-1".into(),
+                ..Default::default()
+            })
+            .expect("ThreadItemsListParams serializes"),
+        );
+        m.insert(
+            methods::THREAD_TURNS_LIST,
+            serde_json::to_value(codex_codes::ThreadTurnsListParams {
+                thread_id: "thread-1".into(),
+                ..Default::default()
+            })
+            .expect("ThreadTurnsListParams serializes"),
+        );
+        m.insert(
+            methods::THREAD_REVERT,
+            serde_json::to_value(codex_codes::ThreadRevertParams {
+                before_turn_id: "turn-2".into(),
+                thread_id: "thread-1".into(),
+            })
+            .expect("ThreadRevertParams serializes"),
+        );
         m
     }
 

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -51,8 +51,10 @@ use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
     ThreadDeleteParams, ThreadDeleteResponse, ThreadForkParams, ThreadForkResponse,
-    ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
-    TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
+    ThreadItemsListParams, ThreadItemsListResponse, ThreadResumeParams, ThreadResumeResponse,
+    ThreadRevertParams, ThreadRevertResponse, ThreadStartParams, ThreadStartResponse,
+    ThreadTurnsListParams, ThreadTurnsListResponse, TurnInterruptParams, TurnInterruptResponse,
+    TurnStartParams, TurnStartResponse, TurnSteerParams, TurnSteerResponse,
 };
 use log::{debug, warn};
 use serde::de::DeserializeOwned;
@@ -264,6 +266,32 @@ impl SyncClient {
     /// or [`SyncClient::next_message`] to consume notifications until `turn/completed`.
     pub fn turn_start(&mut self, params: &TurnStartParams) -> Result<TurnStartResponse> {
         self.request(crate::protocol::methods::TURN_START, params)
+    }
+
+    /// Steer an active turn with additional user input (`turn/steer`).
+    pub fn turn_steer(&mut self, params: &TurnSteerParams) -> Result<TurnSteerResponse> {
+        self.request(crate::protocol::methods::TURN_STEER, params)
+    }
+
+    /// Page through a thread's items in canonical order (`thread/items/list`).
+    pub fn thread_items_list(
+        &mut self,
+        params: &ThreadItemsListParams,
+    ) -> Result<ThreadItemsListResponse> {
+        self.request(crate::protocol::methods::THREAD_ITEMS_LIST, params)
+    }
+
+    /// Page through a thread's turns (`thread/turns/list`).
+    pub fn thread_turns_list(
+        &mut self,
+        params: &ThreadTurnsListParams,
+    ) -> Result<ThreadTurnsListResponse> {
+        self.request(crate::protocol::methods::THREAD_TURNS_LIST, params)
+    }
+
+    /// Revert a thread's durable history to before one turn (`thread/revert`).
+    pub fn thread_revert(&mut self, params: &ThreadRevertParams) -> Result<ThreadRevertResponse> {
+        self.request(crate::protocol::methods::THREAD_REVERT, params)
     }
 
     /// Interrupt an active turn.

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -189,10 +189,12 @@ pub struct AgentMessageDeltaNotification {
 pub struct AgentPath(pub String);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct AnalyticsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub additional: serde_json::Map<String, Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -1253,7 +1255,7 @@ pub struct ComputerUseRequirements {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub analytics: Option<AnalyticsConfig>,
@@ -1305,6 +1307,8 @@ pub struct Config {
     pub tools: Option<ToolsV2>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub web_search: Option<WebSearchMode>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub additional: serde_json::Map<String, Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -2668,12 +2672,20 @@ pub struct GetAccountParams {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GetAccountRateLimitsResponse {
+    #[serde(rename = "accountId", default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
     #[serde(
         rename = "rateLimitResetCredits",
         default,
         skip_serializing_if = "Option::is_none"
     )]
     pub rate_limit_reset_credits: Option<RateLimitResetCreditsSummary>,
+    #[serde(
+        rename = "rateLimitUpsell",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rate_limit_upsell: Option<Value>,
     #[serde(rename = "rateLimits", default)]
     pub rate_limits: Value,
     #[serde(
@@ -4008,6 +4020,14 @@ pub enum McpServerElicitationRequestParams {
     },
     #[serde(rename = "openai/form")]
     OpenaiForm {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        _meta: Option<Value>,
+        message: String,
+        #[serde(rename = "requestedSchema")]
+        requested_schema: Value,
+    },
+    #[serde(rename = "openaiForm")]
+    OpenAiElicitationForm {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         _meta: Option<Value>,
         message: String,
@@ -6415,7 +6435,7 @@ pub enum SandboxPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct SandboxWorkspaceWrite {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_slash_tmp: Option<bool>,

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -1,7 +1,118 @@
 use codex_codes::io::items::{
     CommandExecutionStatus, FileChangeItem, PatchApplyStatus, PatchChangeKind, ThreadItem,
 };
-use codex_codes::{JsonRpcMessage, JsonRpcNotification, Notification, ParseError, ThreadEvent};
+use codex_codes::protocol::{ConfigReadResponse, GetAccountRateLimitsResponse};
+use codex_codes::{
+    JsonRpcMessage, JsonRpcNotification, McpServerElicitationRequestParams, Notification,
+    ParseError, ThreadEvent, ThreadItemsListResponse, ThreadRevertResponse,
+    ThreadTurnsListResponse, TurnSteerResponse,
+};
+
+#[test]
+fn config_read_preserves_additional_properties() {
+    let original = serde_json::json!({
+        "config": {
+            "analytics": {
+                "enabled": true,
+                "unknownAnalyticsSetting": "kept"
+            },
+            "sandbox_workspace_write": {
+                "network_access": true,
+                "writable_roots": ["/tmp/cache"]
+            },
+            "model_providers": {
+                "local": {
+                    "base_url": "http://localhost:11434/v1"
+                }
+            }
+        },
+        "origins": {}
+    });
+
+    let response: ConfigReadResponse =
+        serde_json::from_value(original.clone()).expect("deserialize config/read response");
+
+    assert_eq!(
+        response.config.additional.get("model_providers"),
+        original["config"].get("model_providers")
+    );
+    assert_eq!(
+        response
+            .config
+            .analytics
+            .as_ref()
+            .and_then(|analytics| analytics.additional.get("unknownAnalyticsSetting")),
+        Some(&serde_json::json!("kept"))
+    );
+    assert_eq!(
+        response
+            .config
+            .sandbox_workspace_write
+            .as_ref()
+            .and_then(|sandbox| sandbox.writable_roots.as_deref()),
+        Some(["/tmp/cache".to_string()].as_slice())
+    );
+    assert_eq!(
+        serde_json::to_value(response).expect("serialize config/read response"),
+        original
+    );
+}
+
+#[test]
+fn account_rate_limits_include_account_and_upsell() {
+    let original = serde_json::json!({
+        "accountId": "workspace-123",
+        "rateLimits": {},
+        "rateLimitUpsell": {
+            "message": "Upgrade for more usage"
+        }
+    });
+
+    let response: GetAccountRateLimitsResponse =
+        serde_json::from_value(original.clone()).expect("deserialize rate limits response");
+
+    assert_eq!(response.account_id.as_deref(), Some("workspace-123"));
+    assert_eq!(
+        response.rate_limit_upsell.as_ref(),
+        original.get("rateLimitUpsell")
+    );
+    assert_eq!(
+        serde_json::to_value(response).expect("serialize rate limits response"),
+        original
+    );
+}
+
+#[test]
+fn mcp_elicitation_accepts_current_openai_form_mode() {
+    let request: McpServerElicitationRequestParams = serde_json::from_value(serde_json::json!({
+        "mode": "openaiForm",
+        "message": "Choose an account",
+        "requestedSchema": {"type": "object"}
+    }))
+    .expect("deserialize openaiForm elicitation");
+
+    assert!(matches!(
+        request,
+        McpServerElicitationRequestParams::OpenAiElicitationForm { .. }
+    ));
+}
+
+#[test]
+fn sync_helper_response_types_decode_current_wire_shapes() {
+    let steer: TurnSteerResponse =
+        serde_json::from_value(serde_json::json!({"turnId": "turn-1"})).unwrap();
+    let items: ThreadItemsListResponse =
+        serde_json::from_value(serde_json::json!({"data": []})).unwrap();
+    let turns: ThreadTurnsListResponse =
+        serde_json::from_value(serde_json::json!({"data": []})).unwrap();
+    let revert: ThreadRevertResponse =
+        serde_json::from_value(serde_json::json!({"thread": {}})).unwrap();
+
+    assert_eq!(steer.turn_id, "turn-1");
+    assert!(items.data.is_empty());
+    assert!(turns.data.is_empty());
+    assert_eq!(revert.thread, codex_codes::Thread::default());
+}
 
 /// Parse every line from a JSONL capture file into ThreadEvents,
 /// panicking on any deserialization failure.

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -4002,6 +4002,27 @@
         {
           "properties": {
             "_meta": true,
+            "message": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": [
+                "openaiForm"
+              ],
+              "type": "string"
+            },
+            "requestedSchema": true
+          },
+          "required": [
+            "message",
+            "mode",
+            "requestedSchema"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "_meta": true,
             "elicitationId": {
               "type": "string"
             },
@@ -12142,6 +12163,13 @@
       "GetAccountRateLimitsResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "accountId": {
+            "description": "Account associated with this usage snapshot, when supplied by the backend.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "rateLimitResetCredits": {
             "anyOf": [
               {
@@ -12151,6 +12179,9 @@
                 "type": "null"
               }
             ]
+          },
+          "rateLimitUpsell": {
+            "description": "Optional backend-owned banner from the same usage read. Its nested keys retain the backend's snake_case contract; an absent banner leaves the client's existing UI unchanged."
           },
           "rateLimits": {
             "allOf": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -8174,6 +8174,13 @@
     "GetAccountRateLimitsResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "accountId": {
+          "description": "Account associated with this usage snapshot, when supplied by the backend.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "rateLimitResetCredits": {
           "anyOf": [
             {
@@ -8183,6 +8190,9 @@
               "type": "null"
             }
           ]
+        },
+        "rateLimitUpsell": {
+          "description": "Optional backend-owned banner from the same usage read. Its nested keys retain the backend's snake_case contract; an absent banner leaves the client's existing UI unchanged."
         },
         "rateLimits": {
           "allOf": [

--- a/scripts/codegen_protocol.py
+++ b/scripts/codegen_protocol.py
@@ -268,6 +268,9 @@ def emit_struct(name: str, schema: dict[str, Any]) -> str:
             all_default = False
         body.append("    #[serde(" + ", ".join(attrs) + ")]")
         body.append(f"    pub {rs_field}: {rs_type},")
+    if props and schema.get("additionalProperties") is True:
+        body.append("    #[serde(flatten, default, skip_serializing_if = \"serde_json::Map::is_empty\")]")
+        body.append("    pub additional: serde_json::Map<String, Value>,")
     body.append("}")
     rs = []
     # PartialEq (but not Eq) so structs compose into enums that need
@@ -277,7 +280,14 @@ def emit_struct(name: str, schema: dict[str, Any]) -> str:
     if all_default:
         derives += ", Default"
     rs.append(f"#[derive({derives})]")
-    rs.append('#[serde(rename_all = "camelCase")]')
+    # Config RPC values mirror config.toml and therefore use snake_case,
+    # unlike the rest of app-server v2's camelCase payloads.
+    rename_all = "snake_case" if name in {
+        "AnalyticsConfig",
+        "Config",
+        "SandboxWorkspaceWrite",
+    } else "camelCase"
+    rs.append(f'#[serde(rename_all = "{rename_all}")]')
     rs.extend(body)
     return "\n".join(rs)
 


### PR DESCRIPTION
## Summary

- Preserve unknown `Config` and `AnalyticsConfig` properties.
- Update stable Codex protocol types for rate limits and MCP elicitation.
- Add missing synchronous client helpers.
- Correct schema coverage reporting and typed samples.

## Breaking change

`Config` and `SandboxWorkspaceWrite` now serialize using Codex’s canonical
`snake_case` wire field names. Consumers relying on the previous incorrect
camelCase serialization may need to update.
