### PR TITLE
drift check: JSON equality is the contract, drop byte tier

### DIFF
--- a/scripts/check_codex_schema_drift.py
+++ b/scripts/check_codex_schema_drift.py
@@ -160,14 +160,9 @@ def main() -> int:
             print(f"error: could not fetch/parse upstream {url}: {e}", file=sys.stderr)
             return 2
 
-        if local_text == upstream_text:
-            output_chunks.append(f"- ✅ `{local_name}` — byte-identical to upstream\n")
-            continue
+        # JSON equality is the contract; formatting and key order don't matter.
         if local == upstream:
-            # Different bytes but identical JSON (formatting / key ordering).
-            output_chunks.append(
-                f"- ✳️ `{local_name}` — different bytes, identical JSON (formatting only)\n"
-            )
+            output_chunks.append(f"- ✅ `{local_name}` — matches upstream (JSON-identical)\n")
             continue
 
         any_drift = True


### PR DESCRIPTION
Per Matt: schema snapshots are compared as parsed JSON — formatting and key order are irrelevant. The drift script previously had a two-tier verdict ("byte-identical" fast path, then "✳️ different bytes, identical JSON"); this collapses it to a single ✅ "matches upstream (JSON-identical)" check.

Behavior is unchanged for exit codes (JSON-equal was already exit 0); this only removes the byte-level distinction from the report so JSON-equivalent snapshots (like #339's hand-edited ones) read as fully clean.

Verified live against current main + openai/codex@main: both snapshots report ✅ and exit 0 despite differing bytes.