### PR TITLE
ci: publish crates to crates.io when new versions hit main

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,52 @@
+# Publish any workspace crate whose Cargo.toml version is not yet on
+# crates.io. Runs on every push to main; version bumps land through PRs, so
+# a merged bump publishes automatically and everything else is a fast no-op
+# (one sparse-index read per crate).
+#
+# wirecheck is publish = false and intentionally absent from CRATES.
+
+name: Publish Crates
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-crates
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crates with unpublished versions
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          CRATES="antigravity-codes claude-codes codex-codes muse-codes opencode-codes"
+          failed=0
+          for crate in $CRATES; do
+            version=$(grep '^version' "$crate/Cargo.toml" | head -1 | sed 's/.*"\(.*\)"/\1/')
+            # Sparse-index path for names of 4+ chars: <first2>/<next2>/<name>
+            prefix="${crate:0:2}/${crate:2:2}"
+            listed=$(curl -sf "https://index.crates.io/$prefix/$crate" | \
+              python3 -c "import json,sys; print('\n'.join(json.loads(l)['vers'] for l in sys.stdin))" \
+              || true)
+            if printf '%s\n' "$listed" | grep -qx "$version"; then
+              echo "✅ $crate $version already on crates.io — skipping"
+              continue
+            fi
+            echo "📦 publishing $crate $version"
+            if cargo publish -p "$crate"; then
+              echo "✅ published $crate $version"
+            else
+              echo "❌ publish failed for $crate $version"
+              failed=1
+            fi
+          done
+          exit $failed


### PR DESCRIPTION
New workflow `publish-crates.yml`: on every push to main, for each publishable crate (antigravity-codes, claude-codes, codex-codes, muse-codes, opencode-codes — wirecheck is `publish = false`), read the local `Cargo.toml` version, check the crates.io sparse index, and `cargo publish` any version not yet listed. Already-published versions are a fast no-op (one index read per crate). A failed publish for one crate doesn't block the others; the job fails at the end if any did.

Auth uses the `CARGO_REGISTRY_TOKEN` repo secret (set from the key Matt provided; the local key file was shredded after upload).

The index-check loop was dry-run locally against current main: it correctly skips the four published crates and identifies codex-codes 0.150.2 as unpublished — **so this workflow's first run after merge will publish codex-codes 0.150.2**, which is the intended behavior (version bumps land on main via reviewed PRs; the bump is the publish decision).

Concurrency group serializes runs so overlapping main pushes can't double-publish.