### PR TITLE
codex-codes 0.151.0: re-baseline tested pin to Codex CLI 0.151.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.150.2"
+version = "0.151.0"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.150.2` (tested CLI + 1 crate-side patch), tested against Codex CLI `0.150.1`.
+- **`codex-codes`** — currently `codex-codes 0.151.0`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.0] - 2026-08-31
+
+### Changed
+
+- Re-baseline the tested pin: the full integration suite (23 capture-corpus
+  + 14 live app-server tests, including the strict typed-message audit)
+  passes against Codex CLI **0.151.0**. `version::tested_cli_version()`,
+  both README `Tested against:` lines, and the crate version move to
+  0.151.0 per the version-means-tested convention. No code changes beyond
+  the pin.
+
 ## [0.150.2] - 2026-08-31
 
 Wire-surface work in this release landed via #339 (thanks @marmeladema);

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.150.2"
+version = "0.151.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.150.1
+**Tested against:** Codex CLI 0.151.0
 
 ## Installation
 
@@ -215,7 +215,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.150.1
+**Tested against:** Codex CLI 0.151.0
 
 The crate version means **tested against**: it names the newest Codex CLI
 the live integration suite has passed against. If you're using a different

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.150.1";
+const TESTED_VERSION: &str = "0.151.0";
 
 /// The Codex CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention.


### PR DESCRIPTION
Re-baseline per the version-means-tested convention, approved by Matt.

The full codex integration suite — 23 capture-corpus + 14 live app-server tests, including `test_typed_message_audit_strict` — passed against the installed **codex-cli 0.151.0** (run earlier today, before this PR). All four lockstepped sites move together:

- `version::tested_cli_version()`: 0.150.1 → 0.151.0
- both `codex-codes/README.md` "Tested against:" lines
- root README bullet (offset arithmetic drops out — crate version equals tested CLI)
- crate version 0.150.2 → 0.151.0 + CHANGELOG entry

No code changes beyond the pin; snapshots remain JSON-identical to `openai/codex@main`.

On merge, the new publish-crates workflow (#341) should pick this up and publish 0.151.0 to crates.io automatically — its first version-bump exercise.