### PR TITLE
codex-codes 0.151.1: model plugin/reconcile, resnapshot upstream schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.0"
+version = "0.151.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
-- **`codex-codes`** — currently `codex-codes 0.151.0`, tested against Codex CLI `0.151.0`.
+- **`codex-codes`** — currently `codex-codes 0.151.1`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.1`, tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.1] - 2026-09-01
+
+Resnapshots vs `openai/codex@main`.
+
+### Added
+
+- The `plugin/reconcile` client request (`PluginReconcileParams`,
+  `PluginReconcileResponse`, `PluginReconcileChangedPlugin`) and its
+  `methods::PLUGIN_RECONCILE` constant.
+- `ResponseUsageMetadata.metadata`, an optional free-form JSON value.
+
 ## [0.151.0] - 2026-08-31
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.0"
+version = "0.151.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -562,6 +562,7 @@ mod samples {
             methods::ACCOUNT_USAGE_READ,
             methods::PERMISSION_PROFILE_LIST,
             methods::PLUGIN_INSTALLED,
+            methods::PLUGIN_RECONCILE,
             methods::SKILLS_EXTRA_ROOTS_SET,
             methods::THREAD_GOAL_GET,
             methods::THREAD_GOAL_SET,

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -113,6 +113,7 @@ pub mod methods {
     pub const ACCOUNT_USAGE_READ: &str = "account/usage/read";
     pub const PERMISSION_PROFILE_LIST: &str = "permissionProfile/list";
     pub const PLUGIN_INSTALLED: &str = "plugin/installed";
+    pub const PLUGIN_RECONCILE: &str = "plugin/reconcile";
     pub const SKILLS_EXTRA_ROOTS_SET: &str = "skills/extraRoots/set";
     pub const THREAD_GOAL_GET: &str = "thread/goal/get";
     pub const THREAD_GOAL_SET: &str = "thread/goal/set";

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -321,6 +321,7 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("plugin/installed", json!({})),
         ("plugin/list", json!({})),
         ("plugin/read", json!({"pluginName": "x"})),
+        ("plugin/reconcile", json!({})),
         ("plugin/share/checkout", json!({"remotePluginId": "x"})),
         ("plugin/share/delete", json!({"remotePluginId": "x"})),
         ("plugin/share/list", json!({})),

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -5262,6 +5262,59 @@ pub struct PluginReadResponse {
     pub plugin: PluginDetail,
 }
 
+/// Runtime categories affected by this change, not just capabilities
+/// currently present. Flags describe declarations before runtime policy
+/// filtering. Updates OR the old and new bundle flags; enablement changes and
+/// cached reinstalls use the cached bundle; removals retain the old bundle's
+/// flags.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginReconcileChangedPlugin {
+    #[serde(rename = "hasApps", default)]
+    pub has_apps: bool,
+    #[serde(rename = "hasHooks", default)]
+    pub has_hooks: bool,
+    #[serde(rename = "hasMcps", default)]
+    pub has_mcps: bool,
+    /// Whether either bundle declares skill roots; not a validated inventory
+    /// of enabled skills.
+    #[serde(rename = "hasSkills", default)]
+    pub has_skills: bool,
+    /// Local plugin ID (`name@marketplace`), matching `PluginSummary.id`.
+    #[serde(default)]
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginReconcileParams {
+    /// Optional client-provided reason recorded with the reconciliation
+    /// attempt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Bundle and installed-state changes observed by this pass, not a
+/// runtime-readiness acknowledgement or a cumulative diff since the client's
+/// last request. Other metadata-only changes are not listed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginReconcileResponse {
+    /// Plugins affected by bundle changes, enablement changes, or removals.
+    /// Installed-state changes compare against the previous cached snapshot,
+    /// including cached reinstalls. Removal hints survive cache cleanup
+    /// failures; unchanged plugins are omitted.
+    #[serde(rename = "changedPlugins", default)]
+    pub changed_plugins: Vec<PluginReconcileChangedPlugin>,
+    /// Subset of failures for which the requested bundle could not be
+    /// materialized. A previously cached version may still be available.
+    #[serde(rename = "failedMaterializationRemotePluginIds", default)]
+    pub failed_materialization_remote_plugin_ids: Vec<String>,
+    /// Backend remote plugin IDs whose bundle or identity update failed.
+    #[serde(rename = "failedRemotePluginIds", default)]
+    pub failed_remote_plugin_ids: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginShareCheckoutParams {
@@ -5980,6 +6033,8 @@ pub struct ResourceTemplate {
 pub struct ResponseUsageMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub amount: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -1100,6 +1100,30 @@
             },
             "method": {
               "enum": [
+                "plugin/reconcile"
+              ],
+              "title": "Plugin/reconcileRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/PluginReconcileParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Plugin/reconcileRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "plugin/read"
               ],
               "title": "Plugin/readRequestMethod",
@@ -16181,6 +16205,84 @@
         "title": "PluginReadResponse",
         "type": "object"
       },
+      "PluginReconcileChangedPlugin": {
+        "description": "Runtime categories affected by this change, not just capabilities currently present. Flags describe declarations before runtime policy filtering. Updates OR the old and new bundle flags; enablement changes and cached reinstalls use the cached bundle; removals retain the old bundle's flags.",
+        "properties": {
+          "hasApps": {
+            "type": "boolean"
+          },
+          "hasHooks": {
+            "type": "boolean"
+          },
+          "hasMcps": {
+            "type": "boolean"
+          },
+          "hasSkills": {
+            "description": "Whether either bundle declares skill roots; not a validated inventory of enabled skills.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Local plugin ID (`name@marketplace`), matching `PluginSummary.id`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hasApps",
+          "hasHooks",
+          "hasMcps",
+          "hasSkills",
+          "id"
+        ],
+        "type": "object"
+      },
+      "PluginReconcileParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "reason": {
+            "description": "Optional client-provided reason recorded with the reconciliation attempt.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "PluginReconcileParams",
+        "type": "object"
+      },
+      "PluginReconcileResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Bundle and installed-state changes observed by this pass, not a runtime-readiness acknowledgement or a cumulative diff since the client's last request. Other metadata-only changes are not listed.",
+        "properties": {
+          "changedPlugins": {
+            "description": "Plugins affected by bundle changes, enablement changes, or removals. Installed-state changes compare against the previous cached snapshot, including cached reinstalls. Removal hints survive cache cleanup failures; unchanged plugins are omitted.",
+            "items": {
+              "$ref": "#/definitions/v2/PluginReconcileChangedPlugin"
+            },
+            "type": "array"
+          },
+          "failedMaterializationRemotePluginIds": {
+            "description": "Subset of failures for which the requested bundle could not be materialized. A previously cached version may still be available.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "failedRemotePluginIds": {
+            "description": "Backend remote plugin IDs whose bundle or identity update failed.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "changedPlugins",
+          "failedMaterializationRemotePluginIds",
+          "failedRemotePluginIds"
+        ],
+        "title": "PluginReconcileResponse",
+        "type": "object"
+      },
       "PluginSearchResult": {
         "properties": {
           "marketplaceName": {
@@ -18630,7 +18732,8 @@
               "string",
               "null"
             ]
-          }
+          },
+          "metadata": true
         },
         "type": "object"
       },

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -2528,6 +2528,30 @@
             },
             "method": {
               "enum": [
+                "plugin/reconcile"
+              ],
+              "title": "Plugin/reconcileRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/PluginReconcileParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Plugin/reconcileRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "plugin/read"
               ],
               "title": "Plugin/readRequestMethod",
@@ -12253,6 +12277,84 @@
       "title": "PluginReadResponse",
       "type": "object"
     },
+    "PluginReconcileChangedPlugin": {
+      "description": "Runtime categories affected by this change, not just capabilities currently present. Flags describe declarations before runtime policy filtering. Updates OR the old and new bundle flags; enablement changes and cached reinstalls use the cached bundle; removals retain the old bundle's flags.",
+      "properties": {
+        "hasApps": {
+          "type": "boolean"
+        },
+        "hasHooks": {
+          "type": "boolean"
+        },
+        "hasMcps": {
+          "type": "boolean"
+        },
+        "hasSkills": {
+          "description": "Whether either bundle declares skill roots; not a validated inventory of enabled skills.",
+          "type": "boolean"
+        },
+        "id": {
+          "description": "Local plugin ID (`name@marketplace`), matching `PluginSummary.id`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "hasApps",
+        "hasHooks",
+        "hasMcps",
+        "hasSkills",
+        "id"
+      ],
+      "type": "object"
+    },
+    "PluginReconcileParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "reason": {
+          "description": "Optional client-provided reason recorded with the reconciliation attempt.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "PluginReconcileParams",
+      "type": "object"
+    },
+    "PluginReconcileResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Bundle and installed-state changes observed by this pass, not a runtime-readiness acknowledgement or a cumulative diff since the client's last request. Other metadata-only changes are not listed.",
+      "properties": {
+        "changedPlugins": {
+          "description": "Plugins affected by bundle changes, enablement changes, or removals. Installed-state changes compare against the previous cached snapshot, including cached reinstalls. Removal hints survive cache cleanup failures; unchanged plugins are omitted.",
+          "items": {
+            "$ref": "#/definitions/PluginReconcileChangedPlugin"
+          },
+          "type": "array"
+        },
+        "failedMaterializationRemotePluginIds": {
+          "description": "Subset of failures for which the requested bundle could not be materialized. A previously cached version may still be available.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "failedRemotePluginIds": {
+          "description": "Backend remote plugin IDs whose bundle or identity update failed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "changedPlugins",
+        "failedMaterializationRemotePluginIds",
+        "failedRemotePluginIds"
+      ],
+      "title": "PluginReconcileResponse",
+      "type": "object"
+    },
     "PluginSearchResult": {
       "properties": {
         "marketplaceName": {
@@ -14702,7 +14804,8 @@
             "string",
             "null"
           ]
-        }
+        },
+        "metadata": true
       },
       "type": "object"
     },


### PR DESCRIPTION
## Summary

Nightly drift vs `openai/codex@main` (the successor drift to #337, which was re-baselined by #342 before upstream moved again):

- **New client request `plugin/reconcile`** — adds `PluginReconcileParams`, `PluginReconcileResponse`, and `PluginReconcileChangedPlugin` to `types.rs` (hand-modeled mirroring `codex-rs/app-server-protocol/src/protocol/v2/plugin.rs`, doc comments included), the `methods::PLUGIN_RECONCILE` constant, the schema-coverage registry entry, and a wire sample.
- **`ResponseUsageMetadata.metadata`** — new optional free-form JSON value field.
- Resnapshots both schema JSONs from `openai/codex@main`.
- Patch bump to 0.151.1 (tested pin stays at Codex CLI 0.151.0) + CHANGELOG + README crate-version bullet.

## Verification

- `python3 scripts/check_codex_schema_drift.py` → exit 0 (clean)
- `cargo run --example schema_coverage` → exit 0, `plugin/reconcile` ✓ modeled, sample validates, 179/179 samples
- `cargo test -p codex-codes` → 118 passed, 0 failed
- fmt + clippy clean