### PR TITLE
claude-codes 2.1.239: fix extractor bundle style, model drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.234"
+version = "2.1.239"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.234` (tested CLI + 2 crate-side patches), tested against Claude CLI `2.1.232`.
+- **`claude-codes`** — currently `claude-codes 2.1.239`, tested against Claude CLI `2.1.239`.
 - **`codex-codes`** — currently `codex-codes 0.151.1`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 0.2.2` (tested CLI + 1 crate-side patch), tested against Muse Code `0.2.1` (build `0.2.1-R1215.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.239] - 2026-09-01
+
+Re-baseline against Claude CLI **2.1.239**: the full live integration suite
+(28 tests) passes, so the tested pin (`TESTED_VERSION`, both README
+`Tested against:` lines) and the crate version move to 2.1.239. Models the
+2.1.232 → 2.1.239 stream-json drift (all additive) and repairs the schema
+extractor against the CLI's new bundle style.
+
+### Added
+
+- `AssistantMessage.context_usage` (`ContextUsage` + `ContextCategory`,
+  `ContextOverLimit`, `ContextMcpTool`, `ContextMemoryFile`, `ContextAgent`,
+  `ContextSkill`) — the structured twin of the `/context` report — and
+  `AssistantMessage.batch_tool_uses` (`BatchToolUse`).
+- `ResultMessage.subagent_stats` (`SubagentStats` + `SubagentSpawnRequests`,
+  `SubagentKillCounts`, `SubagentRefusalCounts`) — running totals for
+  subagents started through the Agent tool.
+- `InitMessage.effort` (the session's resolved effort level) and
+  `InitMessage.cloud_session` (raw JSON snapshot on cloud-hosted sessions).
+- `TaskStartedMessage.{is_backgrounded, spawn_depth}`,
+  `CodeChangePublishedMessage.action`, `VcsStateChangedMessage.branch`,
+  `ModelRefusalFallbackMessage.saw_cyber_refusal`, and
+  `UserMessage.seeded_summon`.
+
+### Fixed
+
+- `scripts/extract_claude_sdk_schemas.py` (and with it the nightly drift
+  check, which had been soft-skipping since the CLI's bundler switched
+  styles): schemas are now also discovered in the free-function zod style
+  (`ve(()=>_e({type:Tt("…")}))`) used by CLI 2.1.239+, alongside the
+  zod-namespace style (`Se(()=>E.object({type:E.literal("…")}))`) of older
+  binaries. The snapshot is re-baselined against 2.1.239 (43 wire labels).
+
 ## [2.1.234] - 2026-08-19
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.234"
+version = "2.1.239"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.232
+**Tested against:** Claude CLI 2.1.239
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -73,6 +73,7 @@ impl ClaudeInput {
             inbound_origin: None,
             is_replay: None,
             file_attachments: None,
+            seeded_summon: None,
         })
     }
 
@@ -108,6 +109,7 @@ impl ClaudeInput {
             inbound_origin: None,
             is_replay: None,
             file_attachments: None,
+            seeded_summon: None,
         })
     }
 

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -662,6 +662,9 @@ pub struct UserMessage {
     pub is_replay: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_attachments: Option<Vec<Value>>,
+    /// Desktop host only: the host's own seeded summon (CLI 2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seeded_summon: Option<bool>,
 }
 
 impl UserMessage {
@@ -1249,6 +1252,12 @@ pub struct ModelRefusalFallbackMessage {
     pub request_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_refusal_category: Option<String>,
+    /// Present when any hop of this banner's multi-hop episode was a cyber
+    /// refusal — not only the origin hop `api_refusal_category` describes.
+    /// Re-arm evidence for the CLI's cyber-exclusion header on session
+    /// restore; absent on cyber-free episodes and older CLIs (2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub saw_cyber_refusal: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_refusal_explanation: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1711,6 +1720,20 @@ pub struct InitMessage {
     /// Plugin load warnings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugin_warnings: Vec<PluginDiagnostic>,
+
+    /// The effort level the session will send on its next request — after env
+    /// overrides, session state, org caps, and model-support downgrades
+    /// (`"low"` | `"medium"` | `"high"` | `"xhigh"` | `"max"`). `None` when no
+    /// effort parameter will be sent, or on CLIs before 2.1.239.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+
+    /// Only on init frames written by the headless stream-json client of a
+    /// cloud-hosted session: a per-frame snapshot of the cloud session's id,
+    /// view URL, device binding, and directory-sync state. Absent in every
+    /// other mode. Stored as raw JSON (the shape is internal and evolving).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud_session: Option<Value>,
 }
 
 /// Status system message - sent during operations like context compaction
@@ -1956,6 +1979,18 @@ pub struct TaskStartedMessage {
     /// `Explore`). Absent for `local_bash` tasks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent_type: Option<String>,
+    /// Whether the task was registered in the background (`true`) or in the
+    /// foreground with the spawning tool call blocking on it (`false`). A
+    /// later move to the background arrives as `task_updated`
+    /// `patch.is_backgrounded`. Set for `local_agent` and `local_bash` tasks
+    /// (CLI 2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_backgrounded: Option<bool>,
+    /// Nesting depth of a spawned subagent (`local_agent`) task: 1 for a
+    /// top-level spawn, N+1 when spawned from inside a depth-N agent. Not set
+    /// on other tasks (CLI 2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_depth: Option<u32>,
     /// The prompt handed to the subagent. Present for `local_agent` tasks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
@@ -2138,6 +2173,15 @@ pub struct CodeChangePublishedMessage {
     pub repo: String,
     /// Provider-native change identifier — the PR/MR number as a string.
     pub identifier: String,
+    /// What the session did that produced this announcement: the flag-aware
+    /// `gh pr` verb it ran (`"created"`, `"edited"`, `"merged"`,
+    /// `"commented"`, `"closed"`, `"reopened"`, `"ready"`, `"draft"`,
+    /// `"auto-merge-enabled"`, `"auto-merge-disabled"`), `"pushed"` for a
+    /// push to a branch that has a PR, or `"checked-out"` for `gh pr
+    /// checkout`. Always sent by current producers (CLI 2.1.239+), absent
+    /// only from older ones. Open set — treat unknown values as valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
     pub uuid: String,
     pub session_id: String,
 }
@@ -2154,6 +2198,12 @@ pub struct VcsStateChangedMessage {
     /// The session's working directory — a hint, not necessarily the mutated
     /// repo's path (`git -C` or an inner `cd` mutates elsewhere).
     pub cwd: String,
+    /// The branch a commit landed on or a push updated. Commit and push
+    /// events carry it; a command that pushed several branches emits one push
+    /// event per branch. A best-effort hint: absent whenever attribution is
+    /// uncertain, and never a required key (CLI 2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     pub uuid: String,
     pub session_id: String,
 }
@@ -2227,6 +2277,111 @@ pub struct FeedbackDraftQueuedMessage {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// `{id, name}` of an original `Batch*` tool_use block, carried in
+/// [`AssistantMessage::batch_tool_uses`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BatchToolUse {
+    pub id: String,
+    pub name: String,
+}
+
+/// Structured twin of the `/context` report, carried as
+/// [`AssistantMessage::context_usage`] — the data a client needs to render
+/// the context-usage card without parsing the markdown table. Evolves
+/// additively; a breaking reshape would ship as a sibling field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextUsage {
+    /// Main-loop model the usage was computed for.
+    pub model: String,
+    /// Estimated tokens in use, unclamped — may exceed `raw_max_tokens` when
+    /// over limit.
+    pub total_tokens: u64,
+    /// The window usage is measured against: the resolved autocompact window —
+    /// the model's believed limit, or a smaller compaction-policy window.
+    pub raw_max_tokens: u64,
+    /// Rounded `total_tokens / raw_max_tokens`, 0–100+.
+    pub percentage: u64,
+    /// Present when `total_tokens` exceeds `raw_max_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub over_limit: Option<ContextOverLimit>,
+    /// Usage-by-category rows (`Messages`, `System prompt`, …).
+    #[serde(default)]
+    pub categories: Vec<ContextCategory>,
+    /// Per-tool token contributions of MCP tools.
+    #[serde(default)]
+    pub mcp_tools: Vec<ContextMcpTool>,
+    /// Per-file token contributions of memory files.
+    #[serde(default)]
+    pub memory_files: Vec<ContextMemoryFile>,
+    /// Per-agent token contributions of agent definitions.
+    #[serde(default)]
+    pub agents: Vec<ContextAgent>,
+    /// Per-skill token contributions. Omitted when no skills contribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<Vec<ContextSkill>>,
+}
+
+/// Why and by how much a [`ContextUsage`] exceeds its window.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextOverLimit {
+    pub tokens_over: u64,
+    /// How the window was resolved: `"hard_limit"` (the model's believed
+    /// limit) or `"compaction_window"` (a compaction-policy window).
+    pub kind: String,
+}
+
+/// One row of the `/context` usage-by-category breakdown.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextCategory {
+    /// Display name of the row as the CLI renders it, e.g. `"Messages"`.
+    /// Use `kind` (not this name) to classify the row.
+    pub name: String,
+    pub tokens: u64,
+    /// What the row is: `"used"` content occupies the window; `"free"` is the
+    /// remaining window; `"buffer"` is the compaction reserve; `"deferred"`
+    /// rows are out-of-window tool schemas, excluded from usage math.
+    pub kind: String,
+}
+
+/// An MCP tool's token contribution, in [`ContextUsage::mcp_tools`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextMcpTool {
+    /// Wire name, e.g. `"mcp__linear__create_issue"`.
+    pub name: String,
+    pub server_name: String,
+    pub tokens: u64,
+}
+
+/// A memory file's token contribution, in [`ContextUsage::memory_files`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextMemoryFile {
+    pub path: String,
+    /// Display label of the memory-file source, e.g. `"Project"` or `"User"`.
+    #[serde(rename = "type")]
+    pub file_type: String,
+    pub tokens: u64,
+}
+
+/// An agent definition's token contribution, in [`ContextUsage::agents`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextAgent {
+    pub agent_type: String,
+    /// Raw source identifier, e.g. `"projectSettings"`, `"plugin"`.
+    pub source: String,
+    pub tokens: u64,
+}
+
+/// A skill's token contribution, in [`ContextUsage::skills`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextSkill {
+    pub name: String,
+    /// Raw source identifier, e.g. `"userSettings"`, `"plugin"`.
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_name: Option<String>,
+    pub tokens: u64,
+}
+
 /// Display metadata for a tool-use block carried on the assistant wrapper.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolUseMeta {
@@ -2277,6 +2432,17 @@ pub struct AssistantMessage {
     pub timestamp: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_use_meta: Vec<ToolUseMeta>,
+    /// `{id, name}` of the original `Batch*` tool_use block(s) for a message
+    /// whose content was decomposed into synthetic v1 tool_use blocks.
+    /// Round-tripped so a replayed history reassembles the batch block on the
+    /// wire. Wrapper-level sibling — never inside `message.content`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub batch_tool_uses: Vec<BatchToolUse>,
+    /// Structured twin of the `/context` report, carried on the synthetic
+    /// assistant message that delivers the markdown table. Present only on
+    /// `/context` results from CLIs new enough to attach it (2.1.239+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_usage: Option<ContextUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_meta: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -95,6 +95,12 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none", rename = "modelUsage")]
     pub model_usage: Option<std::collections::BTreeMap<String, ModelUsageEntry>>,
 
+    /// Subagents started through the Agent tool in this session, as running
+    /// totals. Cumulative like `modelUsage`: read the latest result rather
+    /// than summing across results. Absent from CLIs before 2.1.239.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subagent_stats: Option<SubagentStats>,
+
     /// Structured-output payload returned by the model, when enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub structured_output: Option<Value>,
@@ -142,6 +148,68 @@ pub struct DeferredToolUse {
     pub id: String,
     pub name: String,
     pub input: Value,
+}
+
+/// Running totals for subagents started through the Agent tool, carried on
+/// `result` frames (CLI 2.1.239+) as [`ResultMessage::subagent_stats`].
+///
+/// Cumulative for the session: a resumed session starts fresh, and a
+/// mid-session `/clear` zeroes it — though a background subagent that outlives
+/// the `/clear` still records its outcome, so `completed`, `failed`, and
+/// `killed` can then exceed `spawned`. Forked skills, workflows, teammates,
+/// and other internal agents are not counted.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SubagentStats {
+    /// Subagents actually started; a refused or failed launch is not counted.
+    pub spawned: u64,
+    /// Spawns by the `run_in_background` value the model passed; all count as
+    /// `unset` while the parameter is not offered.
+    pub requested: SubagentSpawnRequests,
+    /// Spawns that started in the background after defaults and session
+    /// settings; the rest blocked the spawning tool call.
+    pub started_in_background: u64,
+    /// Spawns by agent type.
+    #[serde(default)]
+    pub by_type: std::collections::BTreeMap<String, u64>,
+    /// Deepest spawn: 1 = started by the main thread, 2 = by a depth-1
+    /// subagent.
+    pub max_depth: u64,
+    /// Spawns made from inside another subagent (depth > 1).
+    pub spawned_by_subagents: u64,
+    pub completed: u64,
+    pub failed: u64,
+    /// Subagents stopped before finishing, by who stopped them.
+    pub killed: SubagentKillCounts,
+    /// Agent tool calls turned down because a limit was reached (other
+    /// denials, such as an unknown agent type, are not counted).
+    pub refused: SubagentRefusalCounts,
+}
+
+/// Spawn counts by the `run_in_background` value the model passed, carried in
+/// [`SubagentStats::requested`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SubagentSpawnRequests {
+    pub background: u64,
+    pub foreground: u64,
+    pub unset: u64,
+}
+
+/// Subagents stopped before finishing, carried in [`SubagentStats::killed`].
+/// `parent` = by another agent through TaskStop; `system` = by Claude Code
+/// itself; `user` = any other stop.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SubagentKillCounts {
+    pub parent: u64,
+    pub user: u64,
+    pub system: u64,
+}
+
+/// Agent tool calls refused at a limit, carried in [`SubagentStats::refused`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SubagentRefusalCounts {
+    pub depth_limit: u64,
+    pub concurrency_limit: u64,
+    pub budget: u64,
 }
 
 /// A record of a tool permission that was denied during the session.

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.220**
+//! Current tested version: **2.1.239**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!
@@ -164,20 +164,21 @@ pub use io::{
 // System message and assistant message types
 pub use io::{
     ApiKeySource, ApiRetryMessage, AssistantErrorKind, BackgroundTaskInfo,
-    BackgroundTasksChangedMessage, CodeChangePublishedMessage, CommandInfo, CommandsChangedMessage,
-    CompactBoundaryMessage, CompactMetadata, CompactionTrigger, ControlRequestProgressMessage,
-    ElicitationCompleteMessage, FailedPersistedFile, FeedbackDraftQueuedMessage,
-    FilesPersistedMessage, HookProgressMessage, HookResponseMessage, HookStartedMessage,
-    InformationalMessage, InitMessage, InitPermissionMode, KnownSystemEvent,
-    LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths, MemoryRecallItem,
-    MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey, MirrorErrorMessage,
-    ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage, NotificationMessage, OutputStyle,
-    PermissionDeniedMessage, PersistedFile, PluginDiagnostic, PluginInfo, PluginInstallMessage,
-    PreservedMessages, PreservedSegment, RefusalFallbackScope, StatusMessage, StatusMessageStatus,
-    StopReason, SummarizeMetadata, SystemMessage, SystemSubtype, TaskNotificationMessage,
-    TaskPatch, TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUpdatedMessage,
-    TaskUsage, ThinkingTokensMessage, ToolResultMeta, ToolUseMeta, VcsMutationKind,
-    VcsStateChangedMessage, WorkerShuttingDownMessage,
+    BackgroundTasksChangedMessage, BatchToolUse, CodeChangePublishedMessage, CommandInfo,
+    CommandsChangedMessage, CompactBoundaryMessage, CompactMetadata, CompactionTrigger,
+    ContextAgent, ContextCategory, ContextMcpTool, ContextMemoryFile, ContextOverLimit,
+    ContextSkill, ContextUsage, ControlRequestProgressMessage, ElicitationCompleteMessage,
+    FailedPersistedFile, FeedbackDraftQueuedMessage, FilesPersistedMessage, HookProgressMessage,
+    HookResponseMessage, HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode,
+    KnownSystemEvent, LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths,
+    MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey,
+    MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
+    NotificationMessage, OutputStyle, PermissionDeniedMessage, PersistedFile, PluginDiagnostic,
+    PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, RefusalFallbackScope,
+    StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage,
+    SystemSubtype, TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage,
+    TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta,
+    ToolUseMeta, VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
 };
 
 // Additional top-level output message wrappers
@@ -199,7 +200,8 @@ pub use io::{
 // Usage types
 pub use io::{
     AssistantUsage, CacheCreationDetails, DeferredToolUse, FastModeDisabledReason, ServerToolUse,
-    SubagentResult, SubagentToolStats, SubagentUsageRollup, UsageInfo,
+    SubagentKillCounts, SubagentRefusalCounts, SubagentResult, SubagentSpawnRequests,
+    SubagentStats, SubagentToolStats, SubagentUsageRollup, UsageInfo,
 };
 
 // Typed tool input types

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.232";
+const TESTED_VERSION: &str = "2.1.239";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -5,32 +5,33 @@
 # see the header of check_claude_schema_drift.py for the comparison contract.
 # union_members: 43
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, error, error_details, is_api_error_message, is_meta, is_virtual, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, uuid
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, uuid
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
 conversation_reset: new_conversation_id, session_id, type, uuid
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
-result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subtype, terminal_reason, total_cost_usd, type, usage, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
 stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, uuid
 system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
-system/code_change_published: identifier, provider, repo, session_id, subtype, type, url, uuid
+system/code_change_published: action, identifier, provider, repo, session_id, subtype, type, url, uuid
 system/commands_changed: commands, session_id, subtype, type, uuid
 system/compact_boundary: compact_metadata, logical_parent_uuid, session_id, subtype, type, uuid
 system/control_request_progress: attempt, error_status, max_retries, request_id, retry_delay_ms, session_id, status, subtype, type, uuid
 system/elicitation_complete: elicitation_id, mcp_server_name, session_id, subtype, type, uuid
+system/feedback_draft_queued: details_preview, draft_id, draft_type, session_id, subtype, title, type, uuid
 system/files_persisted: failed, files, processed_at, session_id, subtype, type, uuid
 system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
 system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
-system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cwd, fast_mode_disabled_reason, fast_mode_state, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, tools, type, uuid
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid
-system/model_refusal_fallback: api_refusal_category, api_refusal_explanation, content, direction, fallback_model, original_model, refused_user_message_uuid, request_id, retracted_message_uuids, scope, session_id, subtype, trigger, type, uuid
+system/model_refusal_fallback: api_refusal_category, api_refusal_explanation, content, direction, fallback_model, original_model, refused_user_message_uuid, request_id, retracted_message_uuids, saw_cyber_refusal, scope, session_id, subtype, trigger, type, uuid
 system/model_refusal_no_fallback: api_refusal_category, api_refusal_explanation, content, original_model, refused_user_message_uuid, request_id, session_id, subtype, type, uuid
 system/notification: color, key, priority, session_id, subtype, text, timeout_ms, type, uuid
 system/permission_denied: agent_id, decision_reason, decision_reason_type, message, session_id, subtype, tool_name, tool_use_id, type, uuid
@@ -39,12 +40,11 @@ system/session_state_changed: session_id, state, subtype, type, uuid
 system/status: compact_error, compact_result, permissionMode, session_id, status, subtype, type, uuid
 system/task_notification: output_file, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
 system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
-system/task_started: description, prompt, session_id, skip_transcript, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
+system/task_started: description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
 system/task_updated: patch, session_id, subtype, task_id, type, uuid
 system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
-system/feedback_draft_queued: details_preview, draft_id, draft_type, session_id, subtype, title, type, uuid
-system/vcs_state_changed: cwd, kind, session_id, subtype, type, uuid
+system/vcs_state_changed: branch, cwd, kind, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid
 tool_progress: elapsed_time_seconds, heartbeat, parent_tool_use_id, session_id, subagent_retry, subagent_type, task_id, tool_name, tool_use_id, type, uuid
 tool_use_summary: preceding_tool_use_ids, session_id, summary, timestamp, type, uuid
-user: client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type
+user: client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type

--- a/scripts/check_claude_schema_drift.py
+++ b/scripts/check_claude_schema_drift.py
@@ -59,17 +59,17 @@ SNAPSHOT = ROOT / "claude-codes" / "tests" / "schemas" / "claude_stream_json_sna
 _KEY = re.compile(r"[A-Za-z_$][\w$]*")
 
 
-def top_level_keys(body: str, zod: str) -> list[str]:
-    """The direct object keys of a schema's outermost `<zod>.object({...})`.
+def top_level_keys(body: str, opener: str) -> list[str]:
+    """The direct object keys of a schema's outermost object combinator.
 
-    `zod` is the minified zod-namespace alias the extractor discovered from
-    the binary (`E` on CLI 2.1.205) — it changes between releases.
+    `opener` is the exact object-schema opening text the extractor discovered
+    from the binary (`E.object({` on CLI 2.1.205, `_e({` on 2.1.239) — it
+    changes between releases.
     String-literal aware (so colons/braces inside `.describe("...")` prose are
-    skipped) and bracket-depth aware (so nested `<zod>.object(...)` keys aren't
+    skipped) and bracket-depth aware (so nested object combinator keys aren't
     counted). Only bare-identifier keys are recognized — all Claude wire
     schemas use them.
     """
-    opener = zod + ".object({"
     start = body.find(opener)
     if start < 0:
         return []
@@ -124,7 +124,7 @@ def build_fingerprint(data: bytes) -> tuple[int, dict[str, list[str]]]:
     for _name, label, body in extraction.results:
         if label in ("(nested)", "NOT FOUND"):
             continue
-        keys = sorted(set(top_level_keys(body, extraction.zod)))
+        keys = sorted(set(top_level_keys(body, extraction.object_open)))
         # First definition wins on the rare label collision; keep it deterministic.
         labeled.setdefault(label, keys)
     return members, labeled

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -46,13 +46,27 @@ _IDENT = rb"[A-Za-z_$][\w$]{1,6}"
 # A minified alias can be a single character (`E` is the zod alias on 2.1.205).
 _ALIAS = rb"[A-Za-z_$][\w$]{0,6}"
 
-# Discovers the alias pair from the anchor schema. Captures:
+# Discovers the alias pair from the anchor schema (zod-namespace bundle
+# style, CLI <= 2.1.23x). Captures:
 #   1. the anchor schema's minified name
 #   2. the lazy-schema wrapper alias (`Se` on CLI 2.1.205)
 #   3. the zod-namespace alias (`E` on CLI 2.1.205)
 ALIAS_DISCOVERY = re.compile(
     rb"(" + _IDENT + rb")=(" + _ALIAS + rb")\(\(\)=>"
     rb"(" + _ALIAS + rb')\.object\(\{type:\3\.literal\("rate_limit_event"\)'
+)
+
+# Same discovery for the free-function bundle style (CLI 2.1.239+): the zod
+# combinators are destructured into standalone minified functions, so the
+# anchor reads `P3b=ve(()=>_e({type:Tt("rate_limit_event"),...}))` instead of
+# `NAME=Se(()=>E.object({type:E.literal("rate_limit_event"),...}))`. Captures:
+#   1. the anchor schema's minified name
+#   2. the lazy-schema wrapper alias (`ve` on 2.1.239)
+#   3. the object-combinator function (`_e` on 2.1.239)
+#   4. the literal-combinator function (`Tt` on 2.1.239)
+FREEFN_DISCOVERY = re.compile(
+    rb"(" + _IDENT + rb")=(" + _ALIAS + rb")\(\(\)=>"
+    rb"(" + _ALIAS + rb')\(\{type:(' + _ALIAS + rb')\("rate_limit_event"\)'
 )
 
 # Calls to other lazy schemas inside a definition body: `ref()`. A plain \b
@@ -65,25 +79,61 @@ REF_CALL = re.compile(r"(?<![\w$.])([A-Za-z_$][\w$]{1,6})\(\)")
 
 
 class WirePatterns(NamedTuple):
-    """Byte-regexes rebuilt from a discovered (lazy, zod) alias pair."""
+    """Byte-regexes rebuilt from a discovered alias set.
+
+    `object_open` is the exact text that opens an object schema body
+    (`E.object({` in the zod-namespace style, `_e({` in the free-function
+    style) and `literal` the callable producing a literal (`E.literal` /
+    `Tt`) — consumers use them to parse bodies without caring which bundle
+    style the binary uses.
+    """
 
     lazy: str
-    zod: str
+    object_open: str
+    literal: str
     def_start: re.Pattern[bytes]
     boundary: re.Pattern[bytes]
     union: re.Pattern[bytes]
 
 
+def _shared_patterns(lazy: bytes) -> tuple[re.Pattern[bytes], re.Pattern[bytes]]:
+    lz = re.escape(lazy)
+    return (
+        # A schema definition starts at `NAME=<lazy>(` and ends where the next begins.
+        re.compile(rb"[^\w$](" + _IDENT + rb")=" + lz + rb"\("),
+        re.compile(rb"[,;({\[]\s*" + _IDENT + rb"=" + lz + rb"\("),
+    )
+
+
 def build_patterns(lazy: bytes, zod: bytes) -> WirePatterns:
     lz, zd = re.escape(lazy), re.escape(zod)
+    def_start, boundary = _shared_patterns(lazy)
     return WirePatterns(
         lazy=lazy.decode(),
-        zod=zod.decode(),
-        # A schema definition starts at `NAME=<lazy>(` and ends where the next begins.
-        def_start=re.compile(rb"[^\w$](" + _IDENT + rb")=" + lz + rb"\("),
-        boundary=re.compile(rb"[,;({\[]\s*" + _IDENT + rb"=" + lz + rb"\("),
+        object_open=zod.decode() + ".object({",
+        literal=zod.decode() + ".literal",
+        def_start=def_start,
+        boundary=boundary,
         union=re.compile(
-            _IDENT + rb"=" + lz + rb"\(\(\)=>" + zd + rb"\.union\(\[[^\]]*\]\)\)"
+            _IDENT + rb"=" + lz + rb"\(\(\)=>" + zd + rb"\.union\(\[[^\]]*\]\)"
+        ),
+    )
+
+
+def build_freefn_patterns(lazy: bytes, objfn: bytes, litfn: bytes) -> WirePatterns:
+    lz = re.escape(lazy)
+    def_start, boundary = _shared_patterns(lazy)
+    return WirePatterns(
+        lazy=lazy.decode(),
+        object_open=objfn.decode() + "({",
+        literal=litfn.decode(),
+        def_start=def_start,
+        boundary=boundary,
+        # The union combinator's minified name isn't recoverable from the
+        # anchor, so accept any `fn([...])` — the caller keeps only the match
+        # that references the anchor schema.
+        union=re.compile(
+            _IDENT + rb"=" + lz + rb"\(\(\)=>" + _ALIAS + rb"\(\[[^\]]*\]\)"
         ),
     )
 
@@ -94,9 +144,10 @@ class Extraction(NamedTuple):
     union_text: str
     # (minified_name, label, body_text) in BFS order from the union members.
     results: list[tuple[str, str, str]]
-    # The discovered zod-namespace alias — needed by consumers that parse the
-    # bodies (e.g. the drift check's top-level-key scan).
-    zod: str
+    # The discovered object-schema opener (`E.object({` / `_e({`) — needed by
+    # consumers that parse the bodies (e.g. the drift check's top-level-key
+    # scan).
+    object_open: str
     # Referenced names with no definition under the schema wrapper — module
     # initializer thunks and helper functions whose call sites happen to
     # match the `ref()` shape, not schemas. Reported for transparency; they
@@ -117,16 +168,18 @@ def resolve_binary(arg: str | None) -> Path:
     return Path(on_path).resolve()
 
 
-def discover_aliases(data: bytes) -> list[tuple[re.Match[bytes], bytes, bytes]]:
-    """All `(anchor_match, lazy_alias, zod_alias)` candidates in the binary.
+def discover_aliases(data: bytes) -> list[tuple[re.Match[bytes], WirePatterns]]:
+    """All `(anchor_match, patterns)` candidates in the binary, both styles.
 
     Anchored on the stable `"rate_limit_event"` literal; the aliases are read
     from the surrounding bytes rather than assumed. Multiple candidates can
     appear when the bundle carries more than one zod copy — callers try each.
     """
-    out = []
+    out: list[tuple[re.Match[bytes], WirePatterns]] = []
     for m in ALIAS_DISCOVERY.finditer(data):
-        out.append((m, m.group(2), m.group(3)))
+        out.append((m, build_patterns(m.group(2), m.group(3))))
+    for m in FREEFN_DISCOVERY.finditer(data):
+        out.append((m, build_freefn_patterns(m.group(2), m.group(3), m.group(4))))
     return out
 
 
@@ -156,10 +209,10 @@ def pick_definition(cands: list[tuple[int, bytes]], anchor: int) -> bytes | None
 
 
 
-def label_of(body: str, zod: str) -> str:
-    z = re.escape(zod)
-    t = re.search(r"type:" + z + r'\.literal\("([a-z_]+)"\)', body)
-    s = re.search(r"subtype:" + z + r'\.literal\("([a-z_0-9]+)"\)', body)
+def label_of(body: str, literal: str) -> str:
+    lit = re.escape(literal)
+    t = re.search(r"type:" + lit + r'\("([a-z_]+)"\)', body)
+    s = re.search(r"subtype:" + lit + r'\("([a-z_0-9]+)"\)', body)
     if t and s:
         return f"{t.group(1)}/{s.group(1)}"
     if t:
@@ -201,11 +254,11 @@ def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> E
             unresolved.append(name)
             continue
         text = body.decode("utf-8", "replace")
-        results.append((name, label_of(text, pats.zod), text))
+        results.append((name, label_of(text, pats.literal), text))
         for ref in REF_CALL.findall(text):
             if ref not in seen and ref not in queue:
                 queue.append(ref)
-    return Extraction(union_text, results, pats.zod, unresolved)
+    return Extraction(union_text, results, pats.object_open, unresolved)
 
 
 def extract_schemas(data: bytes) -> Extraction:
@@ -222,12 +275,11 @@ def extract_schemas(data: bytes) -> Extraction:
         )
 
     failures = []
-    for anchor, lazy, zod in candidates:
-        pats = build_patterns(lazy, zod)
+    for anchor, pats in candidates:
         try:
             return _extract_with(data, anchor, pats)
         except SchemaExtractionError as e:
-            failures.append(f"aliases lazy={pats.lazy} zod={pats.zod}: {e}")
+            failures.append(f"aliases lazy={pats.lazy} object={pats.object_open}: {e}")
     raise SchemaExtractionError(
         "no candidate alias pair yielded the SDK output union: " + "; ".join(failures)
     )
@@ -251,7 +303,7 @@ def main() -> None:
     union_text, results = extraction.union_text, extraction.results
     print(
         f"# union: {len(REF_CALL.findall(union_text))} members"
-        f" (aliases: zod={extraction.zod})",
+        f" (object schema opener: {extraction.object_open!r})",
         file=sys.stderr,
     )
     if extraction.unresolved:


### PR DESCRIPTION
## Summary

The nightly claude-schema-drift workflow has been **silently soft-skipping** ("Claude schema drift check skipped") because the CLI's bundler switched from the zod-namespace style (`Se(()=>E.object({type:E.literal("…")}))`) to a free-function style (`ve(()=>_e({type:Tt("…")}))`), blinding the extractor's anchor discovery. This PR:

1. **Repairs the extractor** (`scripts/extract_claude_sdk_schemas.py` + `check_claude_schema_drift.py`): a second discovery regex for the free-function style, with the object-opener/literal-callable threaded through so both styles parse. Both bundle styles remain supported.
2. **Re-baselines the snapshot** to CLI 2.1.239 (43 wire labels), which the repaired signal shows drifted from 2.1.232 in 9 labels — all additive.
3. **Models the drift** in `claude-codes`:
   - `AssistantMessage.context_usage` (typed `ContextUsage` family — structured `/context` report) and `.batch_tool_uses`
   - `ResultMessage.subagent_stats` (typed `SubagentStats` family — Agent-tool spawn accounting)
   - `InitMessage.effort` + `InitMessage.cloud_session` (raw `Value`, internal/evolving shape, consistent with `mcp_servers`/`skills`)
   - `TaskStartedMessage.{is_backgrounded, spawn_depth}`, `CodeChangePublishedMessage.action`, `VcsStateChangedMessage.branch`, `ModelRefusalFallbackMessage.saw_cyber_refusal`, `UserMessage.seeded_summon`
4. **Moves the tested pin to 2.1.239**: the full live integration suite (28/28) passes against the installed CLI 2.1.239, so `TESTED_VERSION`, the README `Tested against:` lines, and the crate version all move per the version-means-tested convention (this also retires the stale `2.1.220` doc mention in lib.rs).

## Verification

- `python3 scripts/check_claude_schema_drift.py` → exit 0 (extractor finds 43 union members / 68 schemas on 2.1.239; snapshot matches)
- `cargo test -p claude-codes` → all 7 suites pass
- `cargo test -p claude-codes --features integration-tests --test integration_tests` → 28/28 live against CLI 2.1.239
- fmt + clippy clean