### PR TITLE
codex-codes 0.151.2: async user-input questions, thread model fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.1"
+version = "0.151.2"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.239`, tested against Claude CLI `2.1.239`.
-- **`codex-codes`** — currently `codex-codes 0.151.1`, tested against Codex CLI `0.151.0`.
+- **`codex-codes`** — currently `codex-codes 0.151.2`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.1`, tested against Muse Code `1.0.1` (build `1.0.1-R2006.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.2] - 2026-09-02
+
+Resnapshots vs `openai/codex@main`.
+
+### Added
+
+- `AsyncUserInputQuestion` and the optional `questions` field on
+  `ThreadItem::AgentMessage` — questions the agent asks the user
+  asynchronously alongside an agent message.
+- `Thread.model` and `Thread.reasoning_effort`, the configured (or latest
+  persisted) model and reasoning effort for a thread. Both optional; not
+  per-turn execution telemetry.
+
+### Notes
+
+- Upstream also added per-account app-link approval settings
+  (`AppLinkConfig`/`AppLinksConfig` and `AppConfig.links`). Our `Config`
+  type intentionally does not model the `apps` subtree; those keys flow
+  through its flattened `additional` map unchanged.
+
 ## [0.151.1] - 2026-09-01
 
 Resnapshots vs `openai/codex@main`.

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.1"
+version = "0.151.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -71,6 +71,7 @@ use serde_json::Value;
 /// variant captures methods this crate version doesn't model yet, preserving
 /// the raw payload for inspection.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)] // transient wire values, not stored in bulk
 pub enum Notification {
     /// `thread/started`
     ThreadStarted(ThreadStartedNotification),

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -570,6 +570,17 @@ pub enum AskForApproval {
     },
 }
 
+/// A question the agent asks the user asynchronously alongside an
+/// `agentMessage` item (upstream `AsyncUserInputQuestion`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AsyncUserInputQuestion {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+    #[serde(default)]
+    pub title: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AttestationGenerateParams {
@@ -6978,6 +6989,10 @@ pub struct Thread {
     pub project_id: Option<String>,
     #[serde(default)]
     pub id: String,
+    /// Current configured model when loaded, otherwise the latest persisted
+    /// model. Null when unavailable. Not per-turn execution telemetry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     #[serde(rename = "modelProvider", default)]
     pub model_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6992,6 +7007,15 @@ pub struct Thread {
     pub path: Option<String>,
     #[serde(default)]
     pub preview: String,
+    /// Current configured reasoning effort when loaded, otherwise the latest
+    /// persisted effort. Null when unset or unavailable. Not per-turn
+    /// execution telemetry.
+    #[serde(
+        rename = "reasoningEffort",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(rename = "recencyAt", default, skip_serializing_if = "Option::is_none")]
     pub recency_at: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7374,6 +7398,8 @@ pub enum ThreadItem {
         memory_citation: Option<MemoryCitation>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         phase: Option<MessagePhase>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        questions: Option<Vec<AsyncUserInputQuestion>>,
         text: String,
     },
     Plan {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -6999,6 +6999,17 @@
             "default": true,
             "type": "boolean"
           },
+          "links": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AppLinksConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-account approval settings keyed by link ID."
+          },
           "open_world_enabled": {
             "type": [
               "boolean",
@@ -7125,6 +7136,36 @@
           "id",
           "name"
         ],
+        "type": "object"
+      },
+      "AppLinkConfig": {
+        "description": "Approval settings for a connected account within an app.",
+        "properties": {
+          "approvals_reviewer": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ApprovalsReviewer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "default_tools_approval_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AppToolApproval"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "AppLinksConfig": {
+        "description": "Account settings for a single app.",
         "type": "object"
       },
       "AppListUpdatedNotification": {
@@ -7692,6 +7733,27 @@
             "type": "object"
           }
         ]
+      },
+      "AsyncUserInputQuestion": {
+        "additionalProperties": false,
+        "properties": {
+          "options": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
       },
       "AuthMode": {
         "description": "Authentication mode for OpenAI-backed providers.",
@@ -20145,6 +20207,13 @@
             "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
             "type": "string"
           },
+          "model": {
+            "description": "Current configured model when loaded, otherwise the latest persisted model. Null when unavailable. This is not per-turn execution telemetry.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "modelProvider": {
             "description": "Model provider used for this thread (for example, 'openai').",
             "type": "string"
@@ -20180,6 +20249,17 @@
               "string",
               "null"
             ]
+          },
+          "reasoningEffort": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ReasoningEffort"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Current configured reasoning effort when loaded, otherwise the latest persisted effort. Null when unset or unavailable. This is not per-turn execution telemetry."
           },
           "recencyAt": {
             "description": "Unix timestamp (in seconds) used for thread recency ordering.",
@@ -20913,6 +20993,16 @@
                   }
                 ],
                 "default": null
+              },
+              "questions": {
+                "default": null,
+                "items": {
+                  "$ref": "#/definitions/v2/AsyncUserInputQuestion"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
               },
               "text": {
                 "type": "string"

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -490,6 +490,17 @@
           "default": true,
           "type": "boolean"
         },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AppLinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per-account approval settings keyed by link ID."
+        },
         "open_world_enabled": {
           "type": [
             "boolean",
@@ -616,6 +627,36 @@
         "id",
         "name"
       ],
+      "type": "object"
+    },
+    "AppLinkConfig": {
+      "description": "Approval settings for a connected account within an app.",
+      "properties": {
+        "approvals_reviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default_tools_approval_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AppToolApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "AppLinksConfig": {
+      "description": "Account settings for a single app.",
       "type": "object"
     },
     "AppListUpdatedNotification": {
@@ -1183,6 +1224,27 @@
           "type": "object"
         }
       ]
+    },
+    "AsyncUserInputQuestion": {
+      "additionalProperties": false,
+      "properties": {
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "type": "object"
     },
     "AuthMode": {
       "description": "Authentication mode for OpenAI-backed providers.",
@@ -17859,6 +17921,13 @@
           "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
           "type": "string"
         },
+        "model": {
+          "description": "Current configured model when loaded, otherwise the latest persisted model. Null when unavailable. This is not per-turn execution telemetry.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "modelProvider": {
           "description": "Model provider used for this thread (for example, 'openai').",
           "type": "string"
@@ -17894,6 +17963,17 @@
             "string",
             "null"
           ]
+        },
+        "reasoningEffort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Current configured reasoning effort when loaded, otherwise the latest persisted effort. Null when unset or unavailable. This is not per-turn execution telemetry."
         },
         "recencyAt": {
           "description": "Unix timestamp (in seconds) used for thread recency ordering.",
@@ -18627,6 +18707,16 @@
                 }
               ],
               "default": null
+            },
+            "questions": {
+              "default": null,
+              "items": {
+                "$ref": "#/definitions/AsyncUserInputQuestion"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "text": {
               "type": "string"


### PR DESCRIPTION
## Summary

Resolves the current codex schema drift vs `openai/codex@main` (the local `check_codex_schema_drift.py` run flagged 3 added and 3 changed definitions; both snapshots are now JSON-identical to upstream again).

**Crate-side modeling (all additive):**
- New `AsyncUserInputQuestion` type and an optional `questions` field on `ThreadItem::AgentMessage` — questions the agent asks the user asynchronously alongside an agent message.
- `Thread.model` and `Thread.reasoning_effort` (camelCase `reasoningEffort` on the wire): the configured / latest-persisted model and effort for a thread. Both optional and tolerant of older servers.

**Absorbed without modeling:** upstream's new per-account app-link approval settings (`AppLinkConfig`, `AppLinksConfig`, `AppConfig.links`). Our `Config` intentionally doesn't model the `apps` subtree; these keys round-trip through its flattened `additional` map. Noted in the changelog.

`Notification` grew past clippy's `large_enum_variant` threshold via the bigger `Thread`; added the same `#[allow]` already used elsewhere in `messages.rs` rather than a breaking `Box`.

Patch bump 0.151.1 → 0.151.2 with changelog and README version bullet.

## Verification

- `python3 scripts/check_codex_schema_drift.py` → exit 0, both files JSON-identical to upstream
- `cargo run -p codex-codes --example schema_coverage` → exit 0 (99/99 client requests, 10/10 approvals; the 11 unmodeled notifications are pre-existing)
- `cargo test -p codex-codes` → 118 passed
- fmt + clippy clean