### PR TITLE
claude-codes 2.1.258: model stream-json drift, fix fingerprint parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.239"
+version = "2.1.258"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.239`, tested against Claude CLI `2.1.239`.
+- **`claude-codes`** — currently `claude-codes 2.1.258`, tested against Claude CLI `2.1.258`.
 - **`codex-codes`** — currently `codex-codes 0.151.1`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.1`, tested against Muse Code `1.0.1` (build `1.0.1-R2006.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.258] - 2026-09-02
+
+Re-baseline against Claude CLI **2.1.258**: the full live integration suite
+passes, so the tested pin (`TESTED_VERSION`, both README `Tested against:`
+lines) and the crate version move to 2.1.258. Models the 2.1.239 → 2.1.258
+stream-json drift (all additive) and fixes the drift checker's fingerprint
+parser for the CLI's new bundle style.
+
+### Added
+
+- `AssistantMessage.user_message_uuid` and
+  `StreamEventMessage.user_message_uuid` — the client uuid of the user
+  message that triggered the turn, stamped on the turn's first reply frame
+  so a consumer can bind the reply to the send it answers without waiting
+  for the result.
+- `AssistantMessage.local_command_source` and
+  `AssistantMessage.wire_tool_inputs` (internal round-trip fields for
+  history replay).
+- `ResultMessage.queued_turn_count` — user-initiated sends still waiting in
+  the command queue when the result was produced; `> 0` means at least one
+  more turn follows without further input.
+- `InitMessage.footer_indicator` (new `FooterIndicator` type),
+  `InitMessage.powershell_path` (Windows only, nullable), and
+  `InitMessage.worker_epoch` (cloud workers only).
+- `TaskStartedMessage.ambient` and `TaskNotificationMessage.ambient` — true
+  for housekeeping tasks hosts should exclude from activity indicators —
+  plus `TaskNotificationMessage.resource_links` (new `ResourceLink` type):
+  the `resource_link` content blocks a backgrounded MCP task's final result
+  returned by reference.
+- `UserMessage.client_composed` — the client composed the turn from content
+  the user did not type.
+- `RateLimitInfo.unified_windows` (new `UnifiedWindows` /
+  `UnifiedWindowUsage` types) — per-window subscription usage
+  (`five_hour`, `seven_day`, `seven_day_overage_included`) from the
+  `anthropic-ratelimit-unified-*` headers, tracked on every observation
+  unlike the top-level currently-limiting-window fields.
+
+### Fixed
+
+- `scripts/check_claude_schema_drift.py` now treats backtick template
+  literals as strings when reading a schema's top-level keys; the 2.1.258
+  bundle's `.describe()` prose uses them, which previously corrupted the
+  fingerprint (phantom removed/added fields on `system/init`).
+
 ## [2.1.239] - 2026-09-01
 
 Re-baseline against Claude CLI **2.1.239**: the full live integration suite

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.239"
+version = "2.1.258"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.239
+**Tested against:** Claude CLI 2.1.258
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -74,6 +74,7 @@ impl ClaudeInput {
             is_replay: None,
             file_attachments: None,
             seeded_summon: None,
+            client_composed: None,
         })
     }
 
@@ -110,6 +111,7 @@ impl ClaudeInput {
             is_replay: None,
             file_attachments: None,
             seeded_summon: None,
+            client_composed: None,
         })
     }
 

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -109,6 +109,14 @@ pub struct StreamEventMessage {
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ttft_ms: Option<u64>,
+    /// Client uuid of the user message that triggered this turn, stamped on
+    /// the turn's first non-ping stream event (the partial-messages twin of
+    /// [`AssistantMessage::user_message_uuid`]). Absent on every later event
+    /// of the turn and on CLIs before 2.1.258.
+    ///
+    /// [`AssistantMessage::user_message_uuid`]: super::message_types::AssistantMessage::user_message_uuid
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -665,6 +665,10 @@ pub struct UserMessage {
     /// Desktop host only: the host's own seeded summon (CLI 2.1.239+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seeded_summon: Option<bool>,
+    /// True when the client composed this turn from content the user did not
+    /// type; its text is delivered as written (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_composed: Option<bool>,
 }
 
 impl UserMessage {
@@ -1734,6 +1738,35 @@ pub struct InitMessage {
     /// other mode. Stored as raw JSON (the shape is internal and evolving).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cloud_session: Option<Value>,
+
+    /// The server-configured session indicator the terminal renders as a
+    /// `◆ <text>` footer pill — an opaque status note operators set per
+    /// cohort. Absent when nothing is configured (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub footer_indicator: Option<FooterIndicator>,
+
+    /// Windows only: the absolute path of the PowerShell binary this session
+    /// runs PowerShell commands with (PowerShell 7 when installed, else
+    /// Windows PowerShell 5.1), or `Some(None)` when none was found. Absent
+    /// on other platforms and on CLIs before 2.1.258.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub powershell_path: Option<Option<String>>,
+
+    /// This cloud worker's life number (`CLAUDE_CODE_WORKER_EPOCH`): a new
+    /// number each time the session's worker is started, so a client that
+    /// latched an acknowledged epoch re-registers only when it changes.
+    /// Emitted only on cloud workers (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_epoch: Option<u64>,
+}
+
+/// The server-configured session indicator carried on `system/init` (see
+/// [`InitMessage::footer_indicator`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FooterIndicator {
+    /// The label to show — already sanitized to a single line of plain text,
+    /// exactly as the terminal footer renders it after its `◆` glyph.
+    pub text: String,
 }
 
 /// Status system message - sent during operations like context compaction
@@ -1998,6 +2031,12 @@ pub struct TaskStartedMessage {
     pub workflow_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skip_transcript: Option<bool>,
+    /// True for housekeeping tasks the CLI does not surface as user work
+    /// (every `skip_transcript` task, plus auto-started live-update
+    /// watchers); hosts should exclude them from activity indicators
+    /// (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambient: Option<bool>,
     pub uuid: String,
 }
 
@@ -2079,8 +2118,38 @@ pub struct TaskNotificationMessage {
     pub usage: Option<TaskUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skip_transcript: Option<bool>,
+    /// True for housekeeping tasks the CLI does not surface as user work;
+    /// hosts should exclude them from activity indicators (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambient: Option<bool>,
+    /// For a completed backgrounded MCP task (`task_type` `mcp_task`), the
+    /// `resource_link` content blocks of its final result — the files it
+    /// returned by reference, collected from the raw result before the CLI
+    /// renders it as text. Join to the originating call via `tool_use_id`.
+    /// At most 50 links and 64 KiB serialized; absent when the result had
+    /// none or the task is any other type (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_links: Option<Vec<ResourceLink>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+}
+
+/// An MCP `resource_link` content block echoed by the CLI — a file a tool
+/// returned by reference (see [`TaskNotificationMessage::resource_links`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourceLink {
+    pub uri: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "mimeType", default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<serde_json::Map<String, Value>>,
 }
 
 /// API error category attached to assistant wrapper frames.
@@ -2467,6 +2536,30 @@ pub struct AssistantMessage {
     pub attribution_mcp_server: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribution_mcp_tool: Option<String>,
+    /// Client uuid of the user message that triggered this turn (the
+    /// `submitMessage` options.uuid), stamped on the turn's FIRST reply frame
+    /// only — the first assistant message in complete-message mode (with
+    /// `--include-partial-messages` it normally rides the first non-ping
+    /// stream event instead) — so a consumer can bind the reply to the send
+    /// it answers without waiting for the result. Absent on every later frame
+    /// of the turn, on subagent frames, on synthetic/scheduled turns, and
+    /// from CLIs before 2.1.258.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_uuid: Option<String>,
+    /// The originating `system`/`local_command` row's wire-form content
+    /// (escaped frames), carried on the loop-synthesized local-command twin
+    /// so a bridge/SDK history replay rebuilds the model-visible internal row
+    /// instead of replaying the twin's decoded display text. Wrapper-level
+    /// sibling — never inside `message.content` (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_command_source: Option<String>,
+    /// `tool_use.input` exactly as the API produced it, keyed by tool_use id,
+    /// for a message whose `message.content` carries the client-normalized
+    /// input. Round-tripped so a replayed history echoes each earlier tool
+    /// call back to the API as the API emitted it. Wrapper-level sibling —
+    /// never inside `message.content` (CLI 2.1.258+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wire_tool_inputs: Option<serde_json::Map<String, Value>>,
 }
 
 /// Nested message content for assistant messages

--- a/claude-codes/src/io/rate_limit.rs
+++ b/claude-codes/src/io/rate_limit.rs
@@ -378,6 +378,43 @@ pub struct RateLimitInfo {
         skip_serializing_if = "Option::is_none"
     )]
     pub has_chargeable_saved_payment_method: Option<bool>,
+    /// Per-window usage for the subscription rate-limit windows, as read from
+    /// the `anthropic-ratelimit-unified-*` response headers. Unlike the
+    /// top-level `status`/`utilization` fields (which describe the currently
+    /// limiting window), every window is tracked on each observation, and
+    /// events are emitted when a window's rounded percentage or reset time
+    /// moves. Absent until the first response carrying the headers, and
+    /// always absent for API-key, Bedrock, and Vertex sessions (CLI 2.1.258+).
+    #[serde(rename = "unifiedWindows", skip_serializing_if = "Option::is_none")]
+    pub unified_windows: Option<UnifiedWindows>,
+}
+
+/// Per-window subscription usage carried on a rate limit event (see
+/// [`RateLimitInfo::unified_windows`]). Windows absent from the account
+/// state are absent here.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnifiedWindows {
+    /// The session (5-hour) window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<UnifiedWindowUsage>,
+    /// The weekly (7-day) window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<UnifiedWindowUsage>,
+    /// The overage-included weekly window (per-model bucket; present only
+    /// for accounts whose responses carry that window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seven_day_overage_included: Option<UnifiedWindowUsage>,
+}
+
+/// Usage of a single subscription rate-limit window.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnifiedWindowUsage {
+    /// Fraction of the window used — usually 0.0 to 1.0, but values above 1
+    /// occur when usage legitimately runs past a window's cap.
+    pub utilization: f64,
+    /// Unix epoch seconds when the window resets.
+    #[serde(rename = "resetsAt")]
+    pub resets_at: u64,
 }
 
 /// Spend-cap utilization for an overage billing period.

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -43,6 +43,15 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_message_uuid: Option<String>,
 
+    /// User-initiated sends still waiting in the command queue when this
+    /// result was produced. Greater than 0 means at least one more user turn
+    /// (and result) follows without further input, barring cancellation.
+    /// Queued sends may coalesce into fewer turns, so this counts pending
+    /// sends, not remaining results. Absent on fatal startup results, on
+    /// surfaces without a command queue, and on CLIs before 2.1.258.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued_turn_count: Option<u32>,
+
     pub num_turns: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.239**
+//! Current tested version: **2.1.258**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!
@@ -168,14 +168,14 @@ pub use io::{
     CommandsChangedMessage, CompactBoundaryMessage, CompactMetadata, CompactionTrigger,
     ContextAgent, ContextCategory, ContextMcpTool, ContextMemoryFile, ContextOverLimit,
     ContextSkill, ContextUsage, ControlRequestProgressMessage, ElicitationCompleteMessage,
-    FailedPersistedFile, FeedbackDraftQueuedMessage, FilesPersistedMessage, HookProgressMessage,
-    HookResponseMessage, HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode,
-    KnownSystemEvent, LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths,
-    MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey,
-    MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
+    FailedPersistedFile, FeedbackDraftQueuedMessage, FilesPersistedMessage, FooterIndicator,
+    HookProgressMessage, HookResponseMessage, HookStartedMessage, InformationalMessage,
+    InitMessage, InitPermissionMode, KnownSystemEvent, LocalCommandOutputMessage, McpMeta,
+    McpServerError, MemoryPaths, MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole,
+    MirrorErrorKey, MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
     NotificationMessage, OutputStyle, PermissionDeniedMessage, PersistedFile, PluginDiagnostic,
     PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, RefusalFallbackScope,
-    StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage,
+    ResourceLink, StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage,
     SystemSubtype, TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage,
     TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta,
     ToolUseMeta, VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
@@ -194,7 +194,8 @@ pub use io::{assert_fully_wrapped, audit_frame, FrameAudit};
 // Rate limit types
 pub use io::{
     OverageDisabledReason, OveragePeriodUtilization, OverageStatus, RateLimitErrorCode,
-    RateLimitEvent, RateLimitInfo, RateLimitStatus, RateLimitWindow,
+    RateLimitEvent, RateLimitInfo, RateLimitStatus, RateLimitWindow, UnifiedWindowUsage,
+    UnifiedWindows,
 };
 
 // Usage types

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.239";
+const TESTED_VERSION: &str = "2.1.258";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -5,15 +5,15 @@
 # see the header of check_claude_schema_drift.py for the comparison contract.
 # union_members: 43
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, uuid
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, local_command_source, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, uuid, wire_tool_inputs
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
 conversation_reset: new_conversation_id, session_id, type, uuid
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
-result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
-stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, uuid
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
+stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, user_message_uuid, uuid
 system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
 system/code_change_published: action, identifier, provider, repo, session_id, subtype, type, url, uuid
@@ -27,7 +27,7 @@ system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr
 system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
 system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
-system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, footer_indicator, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, powershell_path, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid, worker_epoch
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid
@@ -38,13 +38,13 @@ system/permission_denied: agent_id, decision_reason, decision_reason_type, messa
 system/plugin_install: error, name, session_id, status, subtype, type, uuid
 system/session_state_changed: session_id, state, subtype, type, uuid
 system/status: compact_error, compact_result, permissionMode, session_id, status, subtype, type, uuid
-system/task_notification: output_file, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
+system/task_notification: ambient, output_file, resource_links, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
 system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
-system/task_started: description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
+system/task_started: ambient, description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
 system/task_updated: patch, session_id, subtype, task_id, type, uuid
 system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
 system/vcs_state_changed: branch, cwd, kind, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid
 tool_progress: elapsed_time_seconds, heartbeat, parent_tool_use_id, session_id, subagent_retry, subagent_type, task_id, tool_name, tool_use_id, type, uuid
 tool_use_summary: preceding_tool_use_ids, session_id, summary, timestamp, type, uuid
-user: client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type
+user: client_composed, client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type

--- a/scripts/check_claude_schema_drift.py
+++ b/scripts/check_claude_schema_drift.py
@@ -67,8 +67,10 @@ def top_level_keys(body: str, opener: str) -> list[str]:
     changes between releases.
     String-literal aware (so colons/braces inside `.describe("...")` prose are
     skipped) and bracket-depth aware (so nested object combinator keys aren't
-    counted). Only bare-identifier keys are recognized — all Claude wire
-    schemas use them.
+    counted). Backtick template literals are treated as plain strings — the
+    bundle's describe() prose uses them (interpolation-free) from CLI 2.1.258.
+    Only bare-identifier keys are recognized — all Claude wire schemas use
+    them.
     """
     start = body.find(opener)
     if start < 0:
@@ -79,7 +81,7 @@ def top_level_keys(body: str, opener: str) -> list[str]:
     keys: list[str] = []
     while i < n:
         c = body[i]
-        if c in "\"'":
+        if c in "\"'`":
             quote = c
             i += 1
             while i < n:


### PR DESCRIPTION
## Summary

The nightly claude-schema-drift workflow has been silently *skipping* (green runs, but the step summary says "drift check skipped — anchor schema not found"), masking real drift. Root causes and fixes:

**Fingerprint parser fix.** From CLI 2.1.258 the bundle wraps `.describe()` prose in backtick template literals, which `check_claude_schema_drift.py`'s top-level-key scanner didn't treat as strings — the prose's braces/colons corrupted depth tracking (phantom removed fields on `system/init`, a phantom `only` key). The scanner now skips backtick strings (interpolation-free in this bundle). With the fix, the 2.1.239 snapshot re-verifies clean and the 2.1.258 diff is purely additive.

**Real 2.1.239 → 2.1.258 drift, all additive, now modeled:**
- `assistant` + `stream_event`: `user_message_uuid` — binds the turn's first reply frame to the user send that triggered it, without waiting for the result.
- `assistant`: `local_command_source`, `wire_tool_inputs` (internal history-replay round-trip fields).
- `result` (both subtypes): `queued_turn_count` — pending user sends in the command queue; `> 0` means more turns follow without further input.
- `system/init`: `footer_indicator` (new `FooterIndicator` type), `powershell_path` (Windows, nullable), `worker_epoch` (cloud workers).
- `system/task_started` + `system/task_notification`: `ambient` (housekeeping tasks to exclude from activity indicators); task_notification also gains `resource_links` (new `ResourceLink` type) — files a backgrounded MCP task returned by reference.
- `user`: `client_composed`.
- **Caught live by the wire-fidelity audit, invisible to the fingerprint:** `rate_limit_info.unifiedWindows` — per-window subscription usage (`five_hour` / `seven_day` / `seven_day_overage_included`) from the `anthropic-ratelimit-unified-*` headers. New `UnifiedWindows` / `UnifiedWindowUsage` types.

**Re-baseline.** Crate version, `TESTED_VERSION`, and both README pins move to 2.1.258 per the version-means-tested convention.

## Verification

- Full integration suite (28 live tests + wrapping audit) passes against CLI **2.1.258** — the `unifiedWindows` fix was driven by an actual live-audit failure, then re-run green
- `check_claude_schema_drift.py --binary <2.1.258>` → exit 0 after re-snapshot; extractor runs clean on 2.1.258 (69 schemas, 43 union members)
- `cargo test -p claude-codes` (266 tests), workspace clippy `-D warnings`, fmt, and `claude-codes/build_examples.sh` all green