### PR TITLE
pi-codes 0.84.4: pin forward to tested pi release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pi-codes"
-version = "0.0.1"
+version = "0.84.4"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the least-bad scheme.)
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.1`, tested against Muse Code `1.0.1` (build `1.0.1-R2006.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).
-- **`pi-codes`** — currently `pi-codes 0.0.1` (**alpha** — the crate version is NOT yet pinned to the tested CLI release), tested against pi `0.84.4` (`@earendil-works/pi-coding-agent`; the live tier covers the credential-free RPC surface).
+- **`pi-codes`** — currently `pi-codes 0.84.4`, tested against pi `0.84.4` (`@earendil-works/pi-coding-agent`; live tier: credential-free RPC surface + model turns and tool conformance when a provider key is present).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/pi-codes/CHANGELOG.md
+++ b/pi-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.84.4] - 2026-09-02
+
+### Changed
+
+- Pin forward out of alpha: the crate version now names the tested pi
+  release per the version-means-tested convention. Evidence: the full
+  live tier passes 10/10 against pi 0.84.4 — six credential-free RPC
+  checks, a streamed model turn, and the model-tool conformance trio
+  (read a planted nonce, write a requested nonce, bash with a
+  disk-visible side effect; write/bash verified on disk) — plus the
+  committed 117-record tool-use corpus, fully typed.
+
 ## [0.0.1] - 2026-09-01
 
 ### Added

--- a/pi-codes/Cargo.toml
+++ b/pi-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-codes"
-version = "0.0.1"
+version = "0.84.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/pi-codes/README.md
+++ b/pi-codes/README.md
@@ -5,11 +5,8 @@ Typed Rust SDK for the [pi coding agent](https://github.com/earendil-works/pi)
 `pi --mode json` JSONL event stream and the `pi --mode rpc` stdin/stdout
 command protocol, plus an async (Tokio) RPC client.
 
-**Alpha.** Tested against pi 0.84.4 — but unlike the sibling crates,
-the crate version does **not** yet follow the version-means-tested
-convention: it starts at 0.0.1 while the API settles, and will jump to
-the tested pi release once pinned forward. Expect breaking changes
-between 0.0.x releases.
+Tested against pi 0.84.4. The crate version may carry a patch offset
+above the CLI release for crate-side additions.
 
 ## What's covered
 

--- a/pi-codes/src/lib.rs
+++ b/pi-codes/src/lib.rs
@@ -28,10 +28,9 @@
 //!   errors, so CLI upgrades degrade soft.
 //! - Unmodeled commands can be sent via [`rpc::RpcCommand::Raw`].
 //!
-//! **Alpha**: unlike the sibling crates, the crate version does not yet
-//! name the tested pi release — it stays 0.0.x while the API settles.
-//! The tested release is still machine-readable via
-//! [`version::tested_cli_version`].
+//! The version convention matches the sibling crates: the crate version
+//! names the pi release the live suite last passed against
+//! ([`version::tested_cli_version`]).
 
 pub mod cli;
 pub mod error;


### PR DESCRIPTION
Pin forward out of alpha, approved by Matt after the beef-up round.

Evidence against the installed **pi 0.84.4**: the full live tier passes 10/10 — six credential-free RPC checks, a streamed model turn (gpt-4.1-mini), and the model-tool conformance trio (read planted nonce / write requested nonce / bash with disk-visible side effect, write & bash verified on disk) — plus the committed 117-record tool-use corpus, every line typed.

Moves: crate version `0.0.1 → 0.84.4` (now equal to `TESTED_PI_VERSION`), alpha caveats dropped from the crate README, lib.rs docs, and the root README bullet; standard version-means-tested language in their place; CHANGELOG entry. CI lockstep clause (Cargo.toml ↔ const ↔ READMEs) verified locally with the exact shell fragments.

Publishes 0.84.4 on merge — an *update* to the existing crate, so the workflow token's scope suffices this time.