### PR TITLE
muse-codes 1.0.2: MuseModel enum, re-pin to Muse Code 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ the least-bad scheme.)
 - **`claude-codes`** — currently `claude-codes 2.1.239`, tested against Claude CLI `2.1.239`.
 - **`codex-codes`** — currently `codex-codes 0.151.2`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
-- **`muse-codes`** — currently `muse-codes 1.0.1`, tested against Muse Code `1.0.1` (build `1.0.1-R2006.1`).
+- **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).
 - **`pi-codes`** — currently `pi-codes 0.84.4`, tested against pi `0.84.4` (`@earendil-works/pi-coding-agent`; live tier: credential-free RPC surface + model turns and tool conformance when a provider key is present).
 

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-09-02
+
+### Added
+
+- **`MuseModel`** — model-id enum matching the ClaudeModel/CodexModel
+  pattern: `Spark13`/`Spark13Contributor` (released 2026-09-02;
+  contributor build is the new catalog default) and
+  `Spark12`/`Spark12Contributor`, with `Custom` passthrough,
+  `cli_arg()`, `catalog_default()`, and catalog metadata accessors
+  `context_limit()` / `output_limit()` (1,007,997 / 128,000 for all
+  four). `muse-spark-1.3-contributor` verified live: a real turn
+  configures it and reaches terminal.
+
+### Changed
+
+- Re-baseline the tested pin to Muse Code **1.0.2 (1.0.2-R2040.1)**
+  (hosts auto-rolled from 1.0.1): drift script clean (echo fingerprint
+  identical), full cargo tier green, and the 17-check wirecheck live
+  suite — including the typed meta audit and the conformance tier —
+  passes unchanged.
+
 ## [1.0.1] - 2026-09-01
 
 ### Changed

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -8,7 +8,7 @@ journal on stdout: envelope records covering command intake, run lifecycle,
 task lifecycle, and streamed output. This crate types that stream and ships
 an async Tokio client for driving headless runs.
 
-Tested against Muse Code 1.0.1 (`1.0.1-R2006.1`). The crate version may
+Tested against Muse Code 1.0.2 (`1.0.2-R2040.1`). The crate version may
 carry a patch offset above the CLI release for crate-side additions.
 
 ## Captured, not guessed

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -37,6 +37,7 @@
 // Core modules always available
 pub mod error;
 pub mod io;
+pub mod models;
 pub mod version;
 
 // Client modules
@@ -54,6 +55,7 @@ pub use io::{
     TaskLifecycle, TaskLifecycleEvent, TaskStreamLinked, ToolCorrelationFacts, ToolResult,
     TurnInputUser,
 };
+pub use models::MuseModel;
 
 #[cfg(feature = "async-client")]
 pub use cli::{MuseExecBuilder, Provider, WorktreeMode};

--- a/muse-codes/src/models.rs
+++ b/muse-codes/src/models.rs
@@ -1,0 +1,165 @@
+//! Convenience enum for the models the Meta provider exposes.
+//!
+//! Variants are keyed by human-friendly names; [`MuseModel::cli_arg`]
+//! returns the exact string to pass to `muse exec --model` (and therefore
+//! to `MuseExecBuilder::model`, which accepts the enum via `Into<String>`).
+//!
+//! The table mirrors Muse Code's on-disk model catalog
+//! (`~/.local/share/muse/model-catalog/`, `provider_catalog` source) as of
+//! Muse Code 1.0.2. Unknown or future model ids round-trip through
+//! [`MuseModel::Custom`]. Context/output limits from the same catalog are
+//! exposed via [`MuseModel::context_limit`] / [`MuseModel::output_limit`].
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// A model id accepted by `muse exec --model` (Meta provider).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MuseModel {
+    /// muse-spark-1.3 (`muse-spark-1.3`), released 2026-09-02.
+    Spark13,
+    /// muse-spark-1.3 contributor build (`muse-spark-1.3-contributor`),
+    /// released 2026-09-02. The catalog default as of Muse Code 1.0.2.
+    Spark13Contributor,
+    /// muse-spark-1.2 (`muse-spark-1.2`), released 2026-08-05.
+    Spark12,
+    /// muse-spark-1.2 contributor build (`muse-spark-1.2-contributor`),
+    /// released 2026-08-05.
+    Spark12Contributor,
+    /// A model id not yet known to this version of the crate. Passed to
+    /// the CLI verbatim.
+    Custom(String),
+}
+
+impl MuseModel {
+    /// The string to pass to `muse exec --model` for this model.
+    pub fn cli_arg(&self) -> &str {
+        match self {
+            Self::Spark13 => "muse-spark-1.3",
+            Self::Spark13Contributor => "muse-spark-1.3-contributor",
+            Self::Spark12 => "muse-spark-1.2",
+            Self::Spark12Contributor => "muse-spark-1.2-contributor",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Alias for [`cli_arg`](Self::cli_arg), matching the crate's
+    /// string-enum convention.
+    pub fn as_str(&self) -> &str {
+        self.cli_arg()
+    }
+
+    /// Human-friendly display name (the catalog's `display_label` equals
+    /// the id for every current row).
+    pub fn display_name(&self) -> &str {
+        self.cli_arg()
+    }
+
+    /// Context window in tokens, from the provider catalog. `None` for
+    /// [`Custom`](Self::Custom) ids the catalog hasn't described.
+    pub fn context_limit(&self) -> Option<u64> {
+        match self {
+            Self::Spark13 | Self::Spark13Contributor | Self::Spark12 | Self::Spark12Contributor => {
+                Some(1_007_997)
+            }
+            Self::Custom(_) => None,
+        }
+    }
+
+    /// Maximum output tokens, from the provider catalog. `None` for
+    /// [`Custom`](Self::Custom) ids the catalog hasn't described.
+    pub fn output_limit(&self) -> Option<u64> {
+        match self {
+            Self::Spark13 | Self::Spark13Contributor | Self::Spark12 | Self::Spark12Contributor => {
+                Some(128_000)
+            }
+            Self::Custom(_) => None,
+        }
+    }
+
+    /// The catalog-default model as of Muse Code 1.0.2 — what a run
+    /// resolves to when `--model` is omitted.
+    pub fn catalog_default() -> Self {
+        Self::Spark13Contributor
+    }
+
+    /// Every model known to this version of the crate, newest first.
+    pub fn known() -> &'static [MuseModel] {
+        &[
+            Self::Spark13,
+            Self::Spark13Contributor,
+            Self::Spark12,
+            Self::Spark12Contributor,
+        ]
+    }
+}
+
+impl fmt::Display for MuseModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.cli_arg())
+    }
+}
+
+impl From<&str> for MuseModel {
+    fn from(s: &str) -> Self {
+        match s {
+            "muse-spark-1.3" => Self::Spark13,
+            "muse-spark-1.3-contributor" => Self::Spark13Contributor,
+            "muse-spark-1.2" => Self::Spark12,
+            "muse-spark-1.2-contributor" => Self::Spark12Contributor,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+impl From<MuseModel> for String {
+    fn from(model: MuseModel) -> Self {
+        model.cli_arg().to_string()
+    }
+}
+
+impl Serialize for MuseModel {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.cli_arg())
+    }
+}
+
+impl<'de> Deserialize<'de> for MuseModel {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MuseModel;
+
+    #[test]
+    fn cli_arg_round_trips_for_all_known_models() {
+        for model in MuseModel::known() {
+            assert_eq!(&MuseModel::from(model.cli_arg()), model);
+        }
+        assert_eq!(
+            MuseModel::from("muse-nova-9"),
+            MuseModel::Custom("muse-nova-9".to_string())
+        );
+    }
+
+    #[test]
+    fn catalog_metadata_present_for_known_absent_for_custom() {
+        for model in MuseModel::known() {
+            assert!(model.context_limit().is_some());
+            assert!(model.output_limit().is_some());
+        }
+        assert_eq!(MuseModel::from("muse-nova-9").context_limit(), None);
+    }
+
+    #[test]
+    fn default_is_spark_13_contributor() {
+        assert_eq!(
+            MuseModel::catalog_default().cli_arg(),
+            "muse-spark-1.3-contributor"
+        );
+    }
+}

--- a/muse-codes/src/version.rs
+++ b/muse-codes/src/version.rs
@@ -1,14 +1,14 @@
 //! Version pins this crate is tested against.
 
 /// Muse Code release the live suite last passed against
-/// (`muse --version` reports `Muse Code 1.0.1 (1.0.1-R2006.1)`). The
+/// (`muse --version` reports `Muse Code 1.0.2 (1.0.2-R2040.1)`). The
 /// 0.1.0 and 0.2.1 captures remain committed and still parse — 1.0.1's
 /// wire is a near-superset (its one observed break, `profile_id: null`
 /// on `run.model.configured`, is modeled as `Option`).
-pub const TESTED_MUSE_VERSION: &str = "1.0.1";
+pub const TESTED_MUSE_VERSION: &str = "1.0.2";
 
 /// Full build string of the tested binary.
-pub const TESTED_MUSE_BUILD: &str = "1.0.1-R2006.1";
+pub const TESTED_MUSE_BUILD: &str = "1.0.2-R2040.1";
 
 /// Envelope `schema_version` the models target.
 pub const STREAM_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
Two things, per Matt's ask on the new muse model release:

## MuseModel enum
New `muse_codes::MuseModel` on the ClaudeModel/CodexModel pattern: `Spark13` / `Spark13Contributor` (released **today**, 2026-09-02 — the contributor build is the new catalog default) and `Spark12` / `Spark12Contributor`, plus `Custom` passthrough, `cli_arg()` / `Display` / serde round-trip, `catalog_default()`, and — satisfying agent-portal's standing request — catalog metadata accessors `context_limit()` / `output_limit()` (1,007,997 / 128,000 tokens for all four, from the on-disk provider catalog). Verified live: `muse exec --model muse-spark-1.3-contributor` configures the new model and reaches terminal.

## Drift check on the release
Hosts auto-rolled Muse Code 1.0.1 → **1.0.2 (1.0.2-R2040.1)**. Checked three ways:
- `scripts/check_muse_schema_drift.py` — echo fingerprint identical to snapshot, exit 0
- Full cargo tier (14 unit + 4 corpus + 8 live echo integration) green
- wirecheck live suite **17/17**, including the typed meta audit (18/18 payload types) and the conformance tier (hello/read/write/bash)

No wire drift; tested pin re-baselined to 1.0.2 and crate version follows (patch bump per policy). Auto-publishes on merge.