### PR TITLE
claude-codes 2.1.240: classify login-child exit with 'Login failed:' as CodeRejected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.239"
+version = "2.1.240"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.239`, tested against Claude CLI `2.1.239`.
+- **`claude-codes`** — currently `claude-codes 2.1.240` (tested CLI + 1 crate-side patch), tested against Claude CLI `2.1.239`.
 - **`codex-codes`** — currently `codex-codes 0.151.2`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.240] - 2026-09-02
+
+### Fixed
+
+- Login flows: the login child exiting with `Login failed: <reason>`
+  (CLI >= 2.1.25x behavior after a rejected token exchange) now
+  classifies as `CodeRejected` instead of the `LoginChildExited`
+  forensics blob. Reproduced live on claude 2.1.259 by the agent-portal
+  consumer.
+
 ## [2.1.239] - 2026-09-01
 
 Re-baseline against Claude CLI **2.1.239**: the full live integration suite

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.239"
+version = "2.1.240"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -685,6 +685,16 @@ impl LoginFlow {
                     .map(|(c, _)| c)
                     .or_else(|| reap_exit_code(&mut self.child));
                 let tail = strip_ansi(&guard.0[offset.min(guard.0.len())..]);
+                // CLI >= 2.1.25x no longer parks on the retry screen after a
+                // failed token exchange — it prints "Login failed: <reason>"
+                // and exits(1). That is a rejected code, not a driver
+                // failure: surface it as CodeRejected so callers show the
+                // reason instead of channel forensics. `self.rejected` stays
+                // false deliberately — retry_new_url drives the (now dead)
+                // child's PTY, so drop-and-restart is the only valid retry.
+                if let Some(message) = detect_login_failed_exit(&tail) {
+                    return Err(Error::CodeRejected { message });
+                }
                 return Err(Error::LoginChildExited {
                     code,
                     transcript: format!(
@@ -988,6 +998,22 @@ fn prepare_code_paste(code: &str) -> Result<Vec<u8>> {
 /// cursor-column escapes, so observed stripped output runs words together
 /// and even drops characters (`Requstfailed withstatus code 400` was
 /// captured live) — but every rejection parks on that prompt.
+/// The exit-path rejection signature: CLI >= 2.1.25x prints
+/// `Login failed: <reason>` (e.g. "Request failed with status code 400" for
+/// an expired / already-used / PKCE-mismatched code) and exits instead of
+/// parking on the retry screen. Returns the failure line, newline-collapsed
+/// and bounded like [`detect_oauth_error`]. ASCII anchor, so the lowercased
+/// byte offset indexes the original safely.
+fn detect_login_failed_exit(stripped: &str) -> Option<String> {
+    let start = stripped.to_lowercase().find("login failed")?;
+    let message: String = stripped[start..]
+        .chars()
+        .map(|c| if c == '\n' { ' ' } else { c })
+        .take(240)
+        .collect();
+    Some(message.trim().to_string())
+}
+
 fn detect_oauth_error(stripped: &str) -> Option<String> {
     let collapsed = collapsed_lower(stripped);
     let anchor = if collapsed.contains("oautherror") {
@@ -1173,6 +1199,24 @@ mod tests {
         assert!(msg.starts_with("OAuth error"));
         assert!(msg.contains("Press Enter to retry"));
         assert!(detect_oauth_error("Welcometo Claude Codev2.1.220").is_none());
+    }
+
+    /// Live-captured from claude 2.1.259: a rejected token exchange prints
+    /// `Login failed: <reason>` and the child exits(1) — no retry screen, no
+    /// "OAuth error" literal. The exit path must classify it as a rejected
+    /// code, not a driver failure.
+    #[test]
+    fn exit_path_login_failure_detected_and_bounded() {
+        let tail = "Login failed: Request failed with status code 400\n";
+        let msg = detect_login_failed_exit(tail).expect("detected");
+        assert_eq!(msg, "Login failed: Request failed with status code 400");
+        // Case-insensitive anchor, newlines collapsed, 240-char bound.
+        let long = format!("LOGIN FAILED: {}", "x".repeat(500));
+        let bounded = detect_login_failed_exit(&long).expect("detected");
+        assert!(bounded.chars().count() <= 240);
+        // Ordinary transcripts must not false-positive.
+        assert!(detect_login_failed_exit("Paste code here if prompted >").is_none());
+        assert!(detect_login_failed_exit("Welcome to Claude Code v2.1.259").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Claude CLI ≥ 2.1.25x hard-exits(1) after a failed OAuth token exchange, printing `Login failed: <reason>` — it no longer parks on the retry screen. The submit-wait exit branch only knew the retry-screen shape, so a server-rejected code (expired / already used / PKCE-mismatched from an earlier attempt) surfaced as the `LoginChildExited` channel-forensics blob, which end users saw verbatim in the portal.

The exit branch now runs a dedicated detector for the exit-path failure line and returns `CodeRejected` carrying the CLI's own reason. `self.rejected` deliberately stays false: `retry_new_url` writes Enter into the child's PTY, and this child is dead — drop-and-restart is the only valid retry (already the portal contract).

Reproduced live against claude 2.1.259 (fake code + the flow's real state to force a genuine exchange): before → forensics blob; after → `Authorization code rejected: Login failed: Request failed with status code 400`. Unit tests cover the anchor (case-insensitivity, newline collapse, 240-char bound, no false positives on ordinary transcripts).