### PR TITLE
claude-codes 2.1.259: model 2.1.239 → 2.1.259 stream-json drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.240"
+version = "2.1.259"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.240` (tested CLI + 1 crate-side patch), tested against Claude CLI `2.1.239`.
+- **`claude-codes`** — currently `claude-codes 2.1.259`, tested against Claude CLI `2.1.259`.
 - **`codex-codes`** — currently `codex-codes 0.151.2`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.259] - 2026-09-03
+
+Re-baseline against Claude CLI **2.1.259**: the full live integration suite
+(28 tests) plus the live subagent-wrapping audit pass, so the tested pin
+(`TESTED_VERSION`, both README `Tested against:` lines) and the crate version
+move to 2.1.259. Models the 2.1.239 → 2.1.259 stream-json drift (all additive)
+reported by the nightly drift check on issue #354.
+
+### Added
+
+- `AssistantMessage.user_message_uuid` / `.user_message_uuids` — the client
+  uuid(s) that triggered the turn, stamped on the first reply frame so a
+  consumer can bind the reply to its send. Also added to `StreamEventMessage`
+  and `ResultMessage`.
+- `AssistantMessage.wire_tool_inputs` and `.local_command_source` —
+  round-trip-only wrapper siblings the CLI carries for history replay.
+- `ResultMessage.queued_turn_count` — user-initiated sends still queued when
+  the result was produced.
+- `UserMessage.client_composed` — the client composed the turn from content
+  the user did not type.
+- `McpMeta.resource_links` and `TaskNotificationMessage.resource_links`
+  (`ResourceLink`) — files an MCP tool returned by reference.
+- `TaskStartedMessage.ambient`, `TaskNotificationMessage.ambient`, and
+  `BackgroundTaskInfo.ambient` — housekeeping tasks hosts should hide from
+  activity indicators.
+- `CodeChangePublishedMessage.branch` — the working branch for providers
+  (`gerrit`) whose changes have no head branch of their own.
+- `InitMessage.footer_indicator` (`FooterIndicator`), `.worker_epoch`, and
+  `.powershell_path`.
+- `RateLimitInfo.unified_windows` (`UnifiedRateLimitWindows`,
+  `UnifiedWindowUsage`) and `.rate_limit_grace_active` — per-window
+  subscription usage and the latched grace signal. The nested
+  `unified_windows` drop was surfaced by the live subagent-wrapping audit,
+  not the coarse (top-level-only) drift checker.
+- `AssistantErrorKind::AccountOnHold` — a wire error value the enum was
+  missing.
+
+### Fixed
+
+- The schema drift checker's key scanner now skips backtick template literals
+  (and their `${...}` interpolations) in `.describe()` prose, which 2.1.259's
+  `system/init.footer_indicator` describe introduced — previously they
+  desynced the top-level field scan.
+
 ## [2.1.240] - 2026-09-02
 
 ### Fixed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.240"
+version = "2.1.259"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.239
+**Tested against:** Claude CLI 2.1.259
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -74,6 +74,7 @@ impl ClaudeInput {
             is_replay: None,
             file_attachments: None,
             seeded_summon: None,
+            client_composed: None,
         })
     }
 
@@ -110,6 +111,7 @@ impl ClaudeInput {
             is_replay: None,
             file_attachments: None,
             seeded_summon: None,
+            client_composed: None,
         })
     }
 

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -109,6 +109,18 @@ pub struct StreamEventMessage {
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ttft_ms: Option<u64>,
+    /// Client uuid of the user message that triggered this turn, stamped on
+    /// the turn's first non-ping stream event only so a consumer can bind the
+    /// reply stream to the send it answers. Absent on later stream events, on
+    /// synthetic/scheduled turns, and from CLIs before 2.1.259.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_uuid: Option<String>,
+    /// Client uuids of every user message whose prompt this turn has consumed
+    /// so far, in consumption order. Always contains `user_message_uuid`; at
+    /// most 64 entries. Present exactly when `user_message_uuid` is; absent
+    /// from CLIs before 2.1.259 (fall back to `user_message_uuid`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub user_message_uuids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -572,6 +572,31 @@ pub struct McpMeta {
     pub meta: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub structured_content: Option<Value>,
+    /// The `resource_link` content blocks the MCP tool returned, collected
+    /// from the raw result before the CLI rewrites each into the
+    /// `[Resource link: NAME] URI` text line the model reads. At most 50
+    /// links and 64 KiB serialized; absent when the result had none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_links: Vec<ResourceLink>,
+}
+
+/// A file an MCP tool returned by reference — a `resource_link` content block
+/// as carried on [`McpMeta::resource_links`] and
+/// [`TaskNotificationMessage::resource_links`] (CLI 2.1.259+).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourceLink {
+    pub uri: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "mimeType")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Value>,
 }
 
 /// Display metadata for a `tool_result` block carried on the user wrapper.
@@ -665,6 +690,10 @@ pub struct UserMessage {
     /// Desktop host only: the host's own seeded summon (CLI 2.1.239+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seeded_summon: Option<bool>,
+    /// True when the client composed this turn from content the user did not
+    /// type; its text is delivered as written (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_composed: Option<bool>,
 }
 
 impl UserMessage {
@@ -1423,6 +1452,10 @@ pub struct BackgroundTaskInfo {
     pub task_id: String,
     pub task_type: String,
     pub description: String,
+    /// True for housekeeping tasks the CLI does not surface as user work;
+    /// hosts should exclude them from activity indicators (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambient: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1734,6 +1767,34 @@ pub struct InitMessage {
     /// other mode. Stored as raw JSON (the shape is internal and evolving).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cloud_session: Option<Value>,
+
+    /// The terminal's server-configured `◆ <text>` footer pill, carried so a
+    /// host UI can render the same pill. Absent when nothing is configured
+    /// (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub footer_indicator: Option<FooterIndicator>,
+
+    /// This cloud worker's life (`CLAUDE_CODE_WORKER_EPOCH`): a new number
+    /// each time the session's worker is started. Absent outside cloud
+    /// workers and on CLIs before 2.1.259.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_epoch: Option<u64>,
+
+    /// Windows only: the absolute path of the PowerShell binary this session
+    /// runs PowerShell commands with, or `Some(None)` (wire `null`) when
+    /// none was found. Absent on other platforms and on CLIs before 2.1.259.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub powershell_path: Option<Option<String>>,
+}
+
+/// The server-configured session indicator that the terminal renders as a
+/// `◆ <text>` pill in the prompt footer, carried on `system/init` and the
+/// `initialize` response (CLI 2.1.259+).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FooterIndicator {
+    /// The label to show — already sanitized to a single line of plain text,
+    /// exactly as the terminal footer renders it after its `◆` glyph.
+    pub text: String,
 }
 
 /// Status system message - sent during operations like context compaction
@@ -1998,6 +2059,12 @@ pub struct TaskStartedMessage {
     pub workflow_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skip_transcript: Option<bool>,
+    /// True for housekeeping tasks the CLI does not surface as user work
+    /// (every `skip_transcript` task, plus auto-started live-update
+    /// watchers); hosts should exclude them from activity indicators
+    /// (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambient: Option<bool>,
     pub uuid: String,
 }
 
@@ -2077,8 +2144,19 @@ pub struct TaskNotificationMessage {
     pub tool_use_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<TaskUsage>,
+    /// For a backgrounded MCP task that completed, the `resource_link`
+    /// content blocks of its final result — the files it returned by
+    /// reference — collected from the raw result before the CLI renders it
+    /// as text. Join to the originating call via `tool_use_id`. Absent when
+    /// the result had none or the task is any other type (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_links: Vec<ResourceLink>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skip_transcript: Option<bool>,
+    /// True for housekeeping tasks the CLI does not surface as user work;
+    /// hosts should exclude them from activity indicators (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambient: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
 }
@@ -2088,6 +2166,7 @@ pub struct TaskNotificationMessage {
 pub enum AssistantErrorKind {
     AuthenticationFailed,
     OauthOrgNotAllowed,
+    AccountOnHold,
     BillingError,
     RateLimit,
     Overloaded,
@@ -2104,6 +2183,7 @@ impl AssistantErrorKind {
         match self {
             Self::AuthenticationFailed => "authentication_failed",
             Self::OauthOrgNotAllowed => "oauth_org_not_allowed",
+            Self::AccountOnHold => "account_on_hold",
             Self::BillingError => "billing_error",
             Self::RateLimit => "rate_limit",
             Self::Overloaded => "overloaded",
@@ -2128,6 +2208,7 @@ impl From<&str> for AssistantErrorKind {
         match s {
             "authentication_failed" => Self::AuthenticationFailed,
             "oauth_org_not_allowed" => Self::OauthOrgNotAllowed,
+            "account_on_hold" => Self::AccountOnHold,
             "billing_error" => Self::BillingError,
             "rate_limit" => Self::RateLimit,
             "overloaded" => Self::Overloaded,
@@ -2163,8 +2244,8 @@ impl<'de> Deserialize<'de> for AssistantErrorKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodeChangePublishedMessage {
     /// Forge classification derived from the URL's shape (`github`,
-    /// `github-enterprise`, `gitlab`, `bitbucket` today). Open set — treat an
-    /// unknown value as a valid provider, never as an error.
+    /// `github-enterprise`, `gitlab`, `bitbucket`, `gerrit` today). Open set
+    /// — treat an unknown value as a valid provider, never as an error.
     pub provider: String,
     /// Web URL of the pull/merge request. Unverified.
     pub url: String,
@@ -2177,11 +2258,18 @@ pub struct CodeChangePublishedMessage {
     /// `gh pr` verb it ran (`"created"`, `"edited"`, `"merged"`,
     /// `"commented"`, `"closed"`, `"reopened"`, `"ready"`, `"draft"`,
     /// `"auto-merge-enabled"`, `"auto-merge-disabled"`), `"pushed"` for a
-    /// push to a branch that has a PR, or `"checked-out"` for `gh pr
-    /// checkout`. Always sent by current producers (CLI 2.1.239+), absent
-    /// only from older ones. Open set — treat unknown values as valid.
+    /// push to a branch that has a PR, `"checked-out"` for `gh pr checkout`,
+    /// or `"started"` for the open change on the branch a Claude Desktop
+    /// session began on. Always sent by current producers (CLI 2.1.239+),
+    /// absent only from older ones. Open set — treat unknown values as valid.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
+    /// The session's working branch when it produced the change. Sent only
+    /// for providers whose changes have no head branch of their own
+    /// (`gerrit`), so a host can place the change on that checkout; absent
+    /// for every other provider (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     pub uuid: String,
     pub session_id: String,
 }
@@ -2406,6 +2494,20 @@ pub struct AssistantMessage {
     /// Anthropic API request id that produced this message (e.g. `req_...`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
+    /// Client uuid of the user message that triggered this turn, stamped on
+    /// the turn's first reply frame only so a consumer can bind the reply to
+    /// the send it answers without waiting for the result. Absent on every
+    /// later frame of the turn, on subagent frames, on synthetic/scheduled
+    /// (meta) turns, and from CLIs before 2.1.259.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_uuid: Option<String>,
+    /// Client uuids of every user message whose prompt this turn has consumed
+    /// so far, in consumption order — all members of a prompt batch the host
+    /// merged into this one turn. Always contains `user_message_uuid`; at
+    /// most 64 entries. Present exactly when `user_message_uuid` is; absent
+    /// from CLIs before 2.1.259 (fall back to `user_message_uuid`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub user_message_uuids: Vec<String>,
     /// Subagent type, when this assistant message was produced inside a
     /// `local_agent` subagent (e.g. `general-purpose`, `Explore`).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2438,6 +2540,20 @@ pub struct AssistantMessage {
     /// wire. Wrapper-level sibling — never inside `message.content`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub batch_tool_uses: Vec<BatchToolUse>,
+    /// `tool_use.input` exactly as the API produced it, keyed by `tool_use`
+    /// id, for a message whose `message.content` carries the
+    /// client-normalized input. Round-tripped so a replayed history echoes
+    /// each earlier tool call back to the API as the API emitted it.
+    /// Wrapper-level sibling — never inside `message.content` (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wire_tool_inputs: Option<serde_json::Map<String, Value>>,
+    /// The originating `system/local_command` row's wire-form content,
+    /// carried on the loop-synthesized local-command twin so a bridge/SDK
+    /// history replay rebuilds the internal system row instead of dropping
+    /// the output. Wrapper-level sibling — never inside `message.content`
+    /// (CLI 2.1.259+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_command_source: Option<String>,
     /// Structured twin of the `/context` report, carried on the synthetic
     /// assistant message that delivers the markdown table. Present only on
     /// `/context` results from CLIs new enough to attach it (2.1.239+).

--- a/claude-codes/src/io/rate_limit.rs
+++ b/claude-codes/src/io/rate_limit.rs
@@ -330,6 +330,15 @@ pub struct RateLimitInfo {
     /// Utilization of the rate limit (0.0 to 1.0)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub utilization: Option<f64>,
+    /// Per-window usage for the 5-hour, weekly, and overage-included weekly
+    /// subscription windows, read from the `anthropic-ratelimit-unified-*`
+    /// response headers. Unlike the top-level `status`/`utilization` (which
+    /// describe the currently limiting window), every window here is tracked
+    /// on each observation. Absent until the first response carrying these
+    /// headers, and always absent for API-key/Bedrock/Vertex sessions
+    /// (CLI 2.1.259+).
+    #[serde(rename = "unifiedWindows", skip_serializing_if = "Option::is_none")]
+    pub unified_windows: Option<UnifiedRateLimitWindows>,
     /// Overage status (e.g., rejected, allowed)
     #[serde(skip_serializing_if = "Option::is_none", rename = "overageStatus")]
     pub overage_status: Option<OverageStatus>,
@@ -351,6 +360,16 @@ pub struct RateLimitInfo {
     /// Utilization warning threshold that was crossed (0.0 to 1.0)
     #[serde(rename = "surpassedThreshold", skip_serializing_if = "Option::is_none")]
     pub surpassed_threshold: Option<f64>,
+    /// Latched usage-limit grace signal, observed on responses to requests
+    /// that sent `anthropic-usage-limit: extended`. While set, an
+    /// `overageStatus` of allowed/allowed_warning means paid extra usage
+    /// covers the overflow; combine with `status` rather than reading this
+    /// alone as "still usable" (CLI 2.1.259+).
+    #[serde(
+        rename = "rateLimitGraceActive",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rate_limit_grace_active: Option<bool>,
     /// Monthly service spend-cap utilization (Claude-in-Slack surface)
     #[serde(
         rename = "overagePeriodMonthly",
@@ -385,6 +404,35 @@ pub struct RateLimitInfo {
 pub struct OveragePeriodUtilization {
     /// Fraction of the spend cap consumed (0.0 to 1.0)
     pub utilization: f64,
+}
+
+/// Per-window subscription usage, from
+/// [`RateLimitInfo::unified_windows`] (CLI 2.1.259+). Each window is present
+/// only when the account state carries it.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct UnifiedRateLimitWindows {
+    /// The 5-hour rolling window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<UnifiedWindowUsage>,
+    /// The 7-day rolling window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<UnifiedWindowUsage>,
+    /// The overage-included 7-day window (per-model bucket; present only for
+    /// accounts whose responses carry that window).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day_overage_included: Option<UnifiedWindowUsage>,
+}
+
+/// Usage for a single unified rate-limit window, carried in
+/// [`UnifiedRateLimitWindows`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnifiedWindowUsage {
+    /// Fraction of the window used (usually 0.0–1.0; values above 1.0 occur
+    /// when usage legitimately runs past a window's cap).
+    pub utilization: f64,
+    /// Unix epoch seconds when this window resets.
+    #[serde(rename = "resetsAt")]
+    pub resets_at: u64,
 }
 
 /// Error code carried on a rate limit event when a request was refused.

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -43,6 +43,23 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_message_uuid: Option<String>,
 
+    /// Client uuids of every user message whose prompt this turn consumed, in
+    /// consumption order — all members of a prompt batch the host merged into
+    /// this one turn, plus any queued user message folded into the running
+    /// turn between tool rounds. Always contains `user_message_uuid`; at most
+    /// 64 entries. Absent on delivery-failure/zeroed results and from CLIs
+    /// before 2.1.259 (fall back to `user_message_uuid`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub user_message_uuids: Vec<String>,
+
+    /// User-initiated sends still waiting in the command queue when this
+    /// result was produced. Greater than 0 means at least one more user turn
+    /// follows without further input, barring cancellation. Absent on fatal
+    /// startup results, on surfaces without a command queue, and from CLIs
+    /// before 2.1.259.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queued_turn_count: Option<u64>,
+
     pub num_turns: i32,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -808,5 +825,44 @@ mod tests {
 
         let reserialized = serde_json::to_string(&output).unwrap();
         assert!(reserialized.contains("\"user_message_uuid\":\"um-1\""));
+    }
+
+    #[test]
+    fn test_result_queued_turn_count_and_user_message_uuids() {
+        // CLI 2.1.259 additive fields on the result frame.
+        let json = r#"{
+            "type":"result","subtype":"success","is_error":false,
+            "duration_ms":100,"duration_api_ms":80,"num_turns":1,
+            "session_id":"s1","total_cost_usd":0.01,
+            "user_message_uuid":"um-2",
+            "user_message_uuids":["um-1","um-2"],
+            "queued_turn_count":3
+        }"#;
+        let output: crate::ClaudeOutput = serde_json::from_str(json).unwrap();
+        let crate::ClaudeOutput::Result(res) = &output else {
+            panic!("expected Result");
+        };
+        assert_eq!(res.user_message_uuids, vec!["um-1", "um-2"]);
+        assert_eq!(res.queued_turn_count, Some(3));
+
+        let reserialized = serde_json::to_string(&output).unwrap();
+        assert!(reserialized.contains("\"user_message_uuids\":[\"um-1\",\"um-2\"]"));
+        assert!(reserialized.contains("\"queued_turn_count\":3"));
+
+        // Both fields are absent from older producers and must default cleanly.
+        let old = r#"{
+            "type":"result","subtype":"success","is_error":false,
+            "duration_ms":100,"duration_api_ms":80,"num_turns":1,
+            "session_id":"s1","total_cost_usd":0.01
+        }"#;
+        let output: crate::ClaudeOutput = serde_json::from_str(old).unwrap();
+        let crate::ClaudeOutput::Result(res) = &output else {
+            panic!("expected Result");
+        };
+        assert!(res.user_message_uuids.is_empty());
+        assert_eq!(res.queued_turn_count, None);
+        let reserialized = serde_json::to_string(&output).unwrap();
+        assert!(!reserialized.contains("user_message_uuids"));
+        assert!(!reserialized.contains("queued_turn_count"));
     }
 }

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.239";
+const TESTED_VERSION: &str = "2.1.259";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schema_2_1_259_tests.rs
+++ b/claude-codes/tests/schema_2_1_259_tests.rs
@@ -8,6 +8,9 @@
 use claude_codes::{assert_fully_wrapped, ClaudeOutput};
 use serde_json::json;
 
+/// Pins that an `assistant` frame's 2.1.259 wrapper siblings
+/// (`user_message_uuid(s)`, `wire_tool_inputs`, `local_command_source`)
+/// round-trip without loss.
 #[test]
 fn assistant_carries_user_message_uuids_and_wire_tool_inputs() {
     let frame = json!({
@@ -45,6 +48,8 @@ fn assistant_carries_user_message_uuids_and_wire_tool_inputs() {
     assert!(msg.local_command_source.is_some());
 }
 
+/// Pins that a `stream_event` frame carries the 2.1.259 `user_message_uuid`
+/// / `user_message_uuids` send-binding keys.
 #[test]
 fn stream_event_carries_user_message_uuids() {
     let frame = json!({
@@ -59,6 +64,7 @@ fn stream_event_carries_user_message_uuids() {
     assert_fully_wrapped(&frame);
 }
 
+/// Pins that a `user` frame's 2.1.259 `client_composed` flag round-trips.
 #[test]
 fn user_carries_client_composed() {
     let frame = json!({
@@ -75,6 +81,8 @@ fn user_carries_client_composed() {
     assert_eq!(msg.client_composed, Some(true));
 }
 
+/// Pins that a `system/init` frame's 2.1.259 additions (`footer_indicator`,
+/// `worker_epoch`, `powershell_path`) are modeled and round-trip.
 #[test]
 fn system_init_carries_footer_indicator_worker_epoch_powershell() {
     let frame = json!({
@@ -89,6 +97,8 @@ fn system_init_carries_footer_indicator_worker_epoch_powershell() {
     assert_fully_wrapped(&frame);
 }
 
+/// Pins that a `system/init` frame with an explicit `powershell_path: null`
+/// (Windows-with-no-PowerShell) audits as fully wrapped.
 #[test]
 fn system_init_powershell_path_null_round_trips() {
     // Windows-with-no-PowerShell emits an explicit null; the typed model keeps
@@ -104,6 +114,8 @@ fn system_init_powershell_path_null_round_trips() {
     assert_fully_wrapped(&frame);
 }
 
+/// Pins that a `system/task_started` frame's 2.1.259 `ambient` flag
+/// round-trips.
 #[test]
 fn system_task_started_carries_ambient() {
     let frame = json!({
@@ -118,6 +130,8 @@ fn system_task_started_carries_ambient() {
     assert_fully_wrapped(&frame);
 }
 
+/// Pins that a `system/task_notification` frame's 2.1.259 `ambient` flag and
+/// `resource_links` block round-trip.
 #[test]
 fn system_task_notification_carries_ambient_and_resource_links() {
     let frame = json!({
@@ -137,6 +151,9 @@ fn system_task_notification_carries_ambient_and_resource_links() {
     assert_fully_wrapped(&frame);
 }
 
+/// Pins the nested 2.1.259 `rate_limit_info.unifiedWindows` /
+/// `rateLimitGraceActive` fields the coarse top-level drift checker cannot see
+/// — the drop the live wrapping audit surfaced.
 #[test]
 fn rate_limit_event_carries_unified_windows_and_grace() {
     // Reproduces the live-suite frame that surfaced the nested `unifiedWindows`
@@ -170,6 +187,8 @@ fn rate_limit_event_carries_unified_windows_and_grace() {
     assert_eq!(evt.rate_limit_info.rate_limit_grace_active, Some(true));
 }
 
+/// Pins that a `system/code_change_published` frame's 2.1.259 `branch` field
+/// (gerrit changes with no head branch) round-trips.
 #[test]
 fn system_code_change_published_carries_branch() {
     let frame = json!({

--- a/claude-codes/tests/schema_2_1_259_tests.rs
+++ b/claude-codes/tests/schema_2_1_259_tests.rs
@@ -1,0 +1,194 @@
+//! Coverage for the CLI 2.1.259 stream-json additive drift.
+//!
+//! 2.1.239 → 2.1.259 added top-level fields to several wire types without
+//! removing any (see the drift report on issue #354). Each frame below carries
+//! the new fields and is asserted **fully wrapped** — the typed model captures
+//! every wire field with nothing left in an untyped escape hatch.
+
+use claude_codes::{assert_fully_wrapped, ClaudeOutput};
+use serde_json::json;
+
+#[test]
+fn assistant_carries_user_message_uuids_and_wire_tool_inputs() {
+    let frame = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1",
+        "uuid": "u1",
+        "parent_tool_use_id": null,
+        "user_message_uuid": "um-2",
+        "user_message_uuids": ["um-1", "um-2"],
+        "wire_tool_inputs": {"toolu_1": {"path": "/tmp/x"}},
+        "local_command_source": "<local-command-stdout>hi</local-command-stdout>"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.user_message_uuid.as_deref(), Some("um-2"));
+    assert_eq!(msg.user_message_uuids, vec!["um-1", "um-2"]);
+    assert!(msg.wire_tool_inputs.is_some());
+    assert!(msg.local_command_source.is_some());
+}
+
+#[test]
+fn stream_event_carries_user_message_uuids() {
+    let frame = json!({
+        "type": "stream_event",
+        "event": {"type": "message_start"},
+        "parent_tool_use_id": null,
+        "uuid": "u1",
+        "session_id": "s1",
+        "user_message_uuid": "um-1",
+        "user_message_uuids": ["um-1"]
+    });
+    assert_fully_wrapped(&frame);
+}
+
+#[test]
+fn user_carries_client_composed() {
+    let frame = json!({
+        "type": "user",
+        "message": {"role": "user", "content": []},
+        "session_id": "7fbc568e-2bd6-45aa-b217-a1cf80004ba1",
+        "client_composed": true
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::User(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected user");
+    };
+    assert_eq!(msg.client_composed, Some(true));
+}
+
+#[test]
+fn system_init_carries_footer_indicator_worker_epoch_powershell() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "s1",
+        "uuid": "u1",
+        "footer_indicator": {"text": "◆ test"},
+        "worker_epoch": 7,
+        "powershell_path": "C:\\pwsh.exe"
+    });
+    assert_fully_wrapped(&frame);
+}
+
+#[test]
+fn system_init_powershell_path_null_round_trips() {
+    // Windows-with-no-PowerShell emits an explicit null; the typed model keeps
+    // the distinction between `Some(None)` (wire null) and absent.
+    let frame = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "s1",
+        "uuid": "u1",
+        "powershell_path": null
+    });
+    // A wire null that serializes away is not data loss (see wrap_audit docs).
+    assert_fully_wrapped(&frame);
+}
+
+#[test]
+fn system_task_started_carries_ambient() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "task_started",
+        "session_id": "s1",
+        "uuid": "u1",
+        "task_id": "t1",
+        "description": "background watcher",
+        "ambient": true
+    });
+    assert_fully_wrapped(&frame);
+}
+
+#[test]
+fn system_task_notification_carries_ambient_and_resource_links() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "task_notification",
+        "session_id": "s1",
+        "uuid": "u1",
+        "task_id": "t1",
+        "status": "completed",
+        "summary": "done",
+        "output_file": null,
+        "ambient": false,
+        "resource_links": [
+            {"uri": "file:///tmp/out.txt", "name": "out.txt", "mimeType": "text/plain", "size": 12}
+        ]
+    });
+    assert_fully_wrapped(&frame);
+}
+
+#[test]
+fn rate_limit_event_carries_unified_windows_and_grace() {
+    // Reproduces the live-suite frame that surfaced the nested `unifiedWindows`
+    // drop the coarse (top-level-only) drift checker cannot see.
+    let frame = json!({
+        "type": "rate_limit_event",
+        "session_id": "s1",
+        "uuid": "u1",
+        "rate_limit_info": {
+            "status": "allowed",
+            "resetsAt": 1788441600u64,
+            "rateLimitType": "five_hour",
+            "overageStatus": "rejected",
+            "overageDisabledReason": "org_level_disabled",
+            "isUsingOverage": false,
+            "rateLimitGraceActive": true,
+            "unifiedWindows": {
+                "five_hour": {"resetsAt": 1788441600u64, "utilization": 0.01},
+                "seven_day": {"resetsAt": 1788872400u64, "utilization": 0.2}
+            }
+        }
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::RateLimitEvent(evt) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected rate_limit_event");
+    };
+    let windows = evt.rate_limit_info.unified_windows.unwrap();
+    assert_eq!(windows.five_hour.unwrap().utilization, 0.01);
+    assert_eq!(windows.seven_day.unwrap().resets_at, 1788872400);
+    assert_eq!(evt.rate_limit_info.rate_limit_grace_active, Some(true));
+}
+
+#[test]
+fn system_code_change_published_carries_branch() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "code_change_published",
+        "session_id": "s1",
+        "uuid": "u1",
+        "provider": "gerrit",
+        "url": "https://example-review.googlesource.com/c/1234",
+        "repo": "team/project",
+        "identifier": "1234",
+        "action": "pushed",
+        "branch": "meawoppl/feature"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected system");
+    };
+    let ccp = sys.as_code_change_published().unwrap();
+    assert_eq!(ccp.branch.as_deref(), Some("meawoppl/feature"));
+}

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -5,18 +5,18 @@
 # see the header of check_claude_schema_drift.py for the comparison contract.
 # union_members: 43
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, uuid
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, local_command_source, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_tool_inputs
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
 conversation_reset: new_conversation_id, session_id, type, uuid
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
-result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
-stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, uuid
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
+stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, user_message_uuid, user_message_uuids, uuid
 system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
-system/code_change_published: action, identifier, provider, repo, session_id, subtype, type, url, uuid
+system/code_change_published: action, branch, identifier, provider, repo, session_id, subtype, type, url, uuid
 system/commands_changed: commands, session_id, subtype, type, uuid
 system/compact_boundary: compact_metadata, logical_parent_uuid, session_id, subtype, type, uuid
 system/control_request_progress: attempt, error_status, max_retries, request_id, retry_delay_ms, session_id, status, subtype, type, uuid
@@ -27,7 +27,7 @@ system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr
 system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
 system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
-system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, footer_indicator, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, powershell_path, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid, worker_epoch
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid
@@ -38,13 +38,13 @@ system/permission_denied: agent_id, decision_reason, decision_reason_type, messa
 system/plugin_install: error, name, session_id, status, subtype, type, uuid
 system/session_state_changed: session_id, state, subtype, type, uuid
 system/status: compact_error, compact_result, permissionMode, session_id, status, subtype, type, uuid
-system/task_notification: output_file, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
+system/task_notification: ambient, output_file, resource_links, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
 system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
-system/task_started: description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
+system/task_started: ambient, description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
 system/task_updated: patch, session_id, subtype, task_id, type, uuid
 system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
 system/vcs_state_changed: branch, cwd, kind, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid
 tool_progress: elapsed_time_seconds, heartbeat, parent_tool_use_id, session_id, subagent_retry, subagent_type, task_id, tool_name, tool_use_id, type, uuid
 tool_use_summary: preceding_tool_use_ids, session_id, summary, timestamp, type, uuid
-user: client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type
+user: client_composed, client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type

--- a/scripts/check_claude_schema_drift.py
+++ b/scripts/check_claude_schema_drift.py
@@ -59,6 +59,41 @@ SNAPSHOT = ROOT / "claude-codes" / "tests" / "schemas" / "claude_stream_json_sna
 _KEY = re.compile(r"[A-Za-z_$][\w$]*")
 
 
+def _skip_string(body: str, i: int) -> int:
+    """Given `body[i]` at an opening quote (`"`, `'`, or a backtick template
+    literal), return the index just past the closing quote. Template literals
+    additionally skip `${...}` interpolations (brace-depth aware) so a brace
+    or quote inside one can't desync the scan."""
+    quote = body[i]
+    n = len(body)
+    i += 1
+    while i < n:
+        c = body[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        if quote == "`" and c == "$" and i + 1 < n and body[i + 1] == "{":
+            i += 2
+            brace_depth = 1
+            while i < n and brace_depth:
+                if body[i] == "\\":
+                    i += 2
+                    continue
+                if body[i] in "\"'`":
+                    i = _skip_string(body, i)
+                    continue
+                if body[i] == "{":
+                    brace_depth += 1
+                elif body[i] == "}":
+                    brace_depth -= 1
+                i += 1
+            continue
+        i += 1
+    return n
+
+
 def top_level_keys(body: str, opener: str) -> list[str]:
     """The direct object keys of a schema's outermost object combinator.
 
@@ -66,9 +101,10 @@ def top_level_keys(body: str, opener: str) -> list[str]:
     from the binary (`E.object({` on CLI 2.1.205, `_e({` on 2.1.239) — it
     changes between releases.
     String-literal aware (so colons/braces inside `.describe("...")` prose are
-    skipped) and bracket-depth aware (so nested object combinator keys aren't
-    counted). Only bare-identifier keys are recognized — all Claude wire
-    schemas use them.
+    skipped — including backtick template literals, which 2.1.259's
+    `system/init.footer_indicator` describe introduced) and bracket-depth
+    aware (so nested object combinator keys aren't counted). Only
+    bare-identifier keys are recognized — all Claude wire schemas use them.
     """
     start = body.find(opener)
     if start < 0:
@@ -79,17 +115,8 @@ def top_level_keys(body: str, opener: str) -> list[str]:
     keys: list[str] = []
     while i < n:
         c = body[i]
-        if c in "\"'":
-            quote = c
-            i += 1
-            while i < n:
-                if body[i] == "\\":
-                    i += 2
-                    continue
-                if body[i] == quote:
-                    i += 1
-                    break
-                i += 1
+        if c in "\"'`":
+            i = _skip_string(body, i)
             continue
         if c in "{[(":
             depth += 1


### PR DESCRIPTION
Resolves the schema drift flagged by the nightly check (#354), re-baselined against the newest CLI **2.1.259** rather than the 2.1.255-ish CLI that filed the issue.

## What drifted

The nightly drift check compares the installed `claude` CLI's minified zod schemas against the committed snapshot. Against 2.1.259 it flagged **16 new top-level fields across 9 wire types, all additive** (no removals):

| Wire type | Added |
|---|---|
| `assistant` | `user_message_uuid`, `user_message_uuids`, `wire_tool_inputs`, `local_command_source` |
| `stream_event` | `user_message_uuid`, `user_message_uuids` |
| `result` / `result/success` | `user_message_uuids`, `queued_turn_count` |
| `user` | `client_composed` |
| `system/init` | `footer_indicator`, `worker_epoch`, `powershell_path` |
| `system/task_started` | `ambient` |
| `system/task_notification` | `ambient`, `resource_links` |
| `system/code_change_published` | `branch` |

The live subagent-wrapping audit additionally surfaced a **nested** drop the coarse (top-level-only) checker can't see: `rate_limit_info.unifiedWindows` (plus `rateLimitGraceActive`) were on the wire but not modeled.

## Changes

- Modeled every field above on the corresponding crate types, with `ResourceLink`, `FooterIndicator`, `UnifiedRateLimitWindows` / `UnifiedWindowUsage` support structs. Added the missing `AssistantErrorKind::AccountOnHold` wire value.
- Fixed the drift checker's key scanner to skip backtick template literals (and `${...}` interpolations) in `.describe()` prose — 2.1.259's `footer_indicator` describe introduced one, which had desynced the scan.
- New `schema_2_1_259_tests.rs`: hand-built frames for each changed type, asserted **fully wrapped** via the existing `assert_fully_wrapped` audit.
- Moved the tested pin to 2.1.259 (`TESTED_VERSION`, both READMEs, crate version) after the full live suite passed.

## Verification

- `cargo test -p claude-codes` — all pass
- `cargo test -p claude-codes --features integration-tests` — 28/28 live integration tests + live subagent-wrapping audit pass against CLI 2.1.259
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `check_claude_schema_drift.py` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)