### PR TITLE
codex-codes 0.151.3: resnapshot vs openai/codex@main (#359)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.2"
+version = "0.151.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.259`, tested against Claude CLI `2.1.259`.
-- **`codex-codes`** — currently `codex-codes 0.151.2`, tested against Codex CLI `0.151.0`.
+- **`codex-codes`** — currently `codex-codes 0.151.3`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.3] - 2026-09-04
+
+Resnapshots vs `openai/codex@main` (fixes #359).
+
+### Added
+
+- `GetAccountRateLimitsParams` (`supportsLunaReserve`,
+  `excludeResetCreditDetails`), the client's usage-read capabilities for
+  `account/rateLimits/read`. Both flags are omitted when `false`, so the
+  default serializes as `{}`.
+- `GetAccountRateLimitsResponse.ordinary_usage_allowed`, the backend's
+  permission for ordinary included usage. `None` means unavailable.
+- `RateLimitSnapshot.normal_model_slug`, the normal model whose display name
+  and reasoning options describe a quota alias.
+- `McpServerStatus.tools_error`, set when tool discovery failed and no catalog
+  was returned.
+- `Thread.originator`, the originator recorded when the thread was created,
+  and `ThreadListParams.originators`, a hosted-backend-only originator
+  allowlist.
+
+### Changed
+
+- **Breaking**: `AsyncClient::account_rate_limits_read` now takes a
+  `GetAccountRateLimitsParams`; pass `Default::default()` for the previous
+  behaviour.
+- **Breaking**: `PermissionsRequestApprovalParams.cwd` is a
+  `LegacyAppPathString` rather than an `AbsolutePathBuf`, mirroring
+  upstream. Both are transparent `String` newtypes, so the wire shape is
+  unchanged.
+
+### Notes
+
+- Upstream also added a `configuration_update` `ResponseItem` variant
+  (`ConfigurationReasoning`) and the `ThreadEnvironment` /
+  `ApplicationRequirements` definitions. The raw `ResponseItem` stream is not
+  typed by this crate, and the two new definitions are unreachable from any
+  published method in this schema revision (they back experimental
+  `Thread.environments` / `Config.application` fields upstream), so none are
+  modeled yet.
+- `review/start` detached delivery is now deprecated upstream and emits a
+  `deprecationNotice`; start a thread and run an inline review instead.
+
 ## [0.151.2] - 2026-09-02
 
 Resnapshots vs `openai/codex@main`.

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.2"
+version = "0.151.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -58,8 +58,8 @@ use crate::protocol::{
 };
 use crate::protocol_generated::types::{
     CancelLoginAccountParams, CancelLoginAccountResponse, GetAccountParams,
-    GetAccountRateLimitsResponse, GetAccountResponse, GetAccountTokenUsageResponse,
-    LoginAccountParams, LoginAccountResponse, LogoutAccountResponse,
+    GetAccountRateLimitsParams, GetAccountRateLimitsResponse, GetAccountResponse,
+    GetAccountTokenUsageResponse, LoginAccountParams, LoginAccountResponse, LogoutAccountResponse,
 };
 use log::{debug, error, warn};
 use serde::de::DeserializeOwned;
@@ -515,12 +515,16 @@ impl AsyncClient {
     }
 
     /// `account/rateLimits/read` — current rate-limit windows.
-    pub async fn account_rate_limits_read(&mut self) -> Result<GetAccountRateLimitsResponse> {
-        self.request(
-            crate::protocol::methods::ACCOUNT_RATELIMITS_READ,
-            &serde_json::json!({}),
-        )
-        .await
+    ///
+    /// `params` declares the client's usage-read capabilities;
+    /// `GetAccountRateLimitsParams::default()` serializes as `{}` and matches
+    /// the pre-capability wire shape.
+    pub async fn account_rate_limits_read(
+        &mut self,
+        params: GetAccountRateLimitsParams,
+    ) -> Result<GetAccountRateLimitsResponse> {
+        self.request(crate::protocol::methods::ACCOUNT_RATELIMITS_READ, &params)
+            .await
     }
 
     /// `account/usage/read` — token-usage summary for the account.

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -2680,11 +2680,46 @@ pub struct GetAccountParams {
     pub refresh_token: Option<bool>,
 }
 
+/// Usage-read capabilities of the requesting client, never inferred from its
+/// experiment arm. Both flags are omitted from the wire when `false`, so the
+/// default value serializes as `{}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAccountRateLimitsParams {
+    /// Skip the separate reset-credit detail lookup for background usage
+    /// polls. The usage response still includes the available count;
+    /// omitted/false preserves detailed reads.
+    #[serde(
+        rename = "excludeResetCreditDetails",
+        default,
+        skip_serializing_if = "std::ops::Not::not"
+    )]
+    pub exclude_reset_credit_details: bool,
+    /// The client supports automatic Luna Reserve fallback. For eligible
+    /// ChatGPT CLI users, allow the backend to record experiment exposure
+    /// after ordinary usage is blocked.
+    #[serde(
+        rename = "supportsLunaReserve",
+        default,
+        skip_serializing_if = "std::ops::Not::not"
+    )]
+    pub supports_luna_reserve: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GetAccountRateLimitsResponse {
     #[serde(rename = "accountId", default, skip_serializing_if = "Option::is_none")]
     pub account_id: Option<String>,
+    /// Backend permission for ordinary included usage, validated against the
+    /// active account. `None` means unavailable; clients must not infer
+    /// recovery from percentages or reset times.
+    #[serde(
+        rename = "ordinaryUsageAllowed",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub ordinary_usage_allowed: Option<bool>,
     #[serde(
         rename = "rateLimitResetCredits",
         default,
@@ -4190,6 +4225,14 @@ pub struct McpServerStatus {
     pub server_info: Option<McpServerInfo>,
     #[serde(default)]
     pub tools: std::collections::BTreeMap<String, Tool>,
+    /// Tool discovery failed and no catalog was returned. `None` when a
+    /// catalog is returned, including cached or empty catalogs.
+    #[serde(
+        rename = "toolsError",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tools_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -4845,7 +4888,7 @@ pub struct PermissionProfileSummary {
 #[serde(rename_all = "camelCase")]
 pub struct PermissionsRequestApprovalParams {
     #[serde()]
-    pub cwd: AbsolutePathBuf,
+    pub cwd: LegacyAppPathString,
     #[serde(
         rename = "environmentId",
         default,
@@ -5822,6 +5865,14 @@ pub struct RateLimitSnapshot {
     pub limit_id: Option<String>,
     #[serde(rename = "limitName", default, skip_serializing_if = "Option::is_none")]
     pub limit_name: Option<String>,
+    /// Normal model whose display name and reasoning options describe this
+    /// quota alias.
+    #[serde(
+        rename = "normalModelSlug",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub normal_model_slug: Option<String>,
     #[serde(rename = "planType", default, skip_serializing_if = "Option::is_none")]
     pub plan_type: Option<PlanType>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6997,6 +7048,11 @@ pub struct Thread {
     pub model_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Originator recorded when the thread was created, independent of its
+    /// current client or executor. `None` when the recorded originator is
+    /// unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub originator: Option<String>,
     #[serde(
         rename = "parentThreadId",
         default,
@@ -7635,6 +7691,11 @@ pub struct ThreadListParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub model_providers: Option<Vec<String>>,
+    /// Optional originator allowlist, matching any supplied value exactly.
+    /// Supported by hosted backends only; the local app-server rejects a
+    /// nonempty list. Omitted or empty lists leave originators unrestricted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub originators: Option<Vec<String>>,
     #[serde(
         rename = "searchTerm",
         default,

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -1,7 +1,10 @@
 use codex_codes::io::items::{
     CommandExecutionStatus, FileChangeItem, PatchApplyStatus, PatchChangeKind, ThreadItem,
 };
-use codex_codes::protocol::{ConfigReadResponse, GetAccountRateLimitsResponse};
+use codex_codes::protocol::{
+    ConfigReadResponse, GetAccountRateLimitsParams, GetAccountRateLimitsResponse, McpServerStatus,
+    Thread, ThreadListParams,
+};
 use codex_codes::{
     JsonRpcMessage, JsonRpcNotification, McpServerElicitationRequestParams, Notification,
     ParseError, ThreadEvent, ThreadItemsListResponse, ThreadRevertResponse,
@@ -82,6 +85,101 @@ fn account_rate_limits_include_account_and_upsell() {
         serde_json::to_value(response).expect("serialize rate limits response"),
         original
     );
+}
+
+/// GetAccountRateLimitsParams omits false capability flags (default is `{}`) and writes set ones in camelCase.
+#[test]
+fn account_rate_limits_params_omit_false_capabilities() {
+    assert_eq!(
+        serde_json::to_value(GetAccountRateLimitsParams::default()).unwrap(),
+        serde_json::json!({})
+    );
+
+    let params = GetAccountRateLimitsParams {
+        supports_luna_reserve: true,
+        exclude_reset_credit_details: true,
+    };
+    let wire = serde_json::to_value(&params).unwrap();
+    assert_eq!(
+        wire,
+        serde_json::json!({
+            "supportsLunaReserve": true,
+            "excludeResetCreditDetails": true
+        })
+    );
+    let back: GetAccountRateLimitsParams = serde_json::from_value(wire).unwrap();
+    assert_eq!(back, params);
+}
+
+/// GetAccountRateLimitsResponse decodes ordinaryUsageAllowed and RateLimitSnapshot.normalModelSlug, round-tripping both.
+#[test]
+fn account_rate_limits_decode_usage_permission_and_model_slug() {
+    let original = serde_json::json!({
+        "ordinaryUsageAllowed": false,
+        "rateLimits": {
+            "limitId": "codex",
+            "normalModelSlug": "gpt-5-codex"
+        }
+    });
+
+    let response: GetAccountRateLimitsResponse = serde_json::from_value(original.clone()).unwrap();
+    assert_eq!(response.ordinary_usage_allowed, Some(false));
+    assert_eq!(
+        serde_json::to_value(&response).unwrap()["rateLimits"]["normalModelSlug"],
+        "gpt-5-codex"
+    );
+    assert_eq!(serde_json::to_value(response).unwrap(), original);
+}
+
+/// Thread.originator and ThreadListParams.originators round-trip and stay absent when unset.
+#[test]
+fn thread_originator_fields_round_trip() {
+    let thread: Thread = serde_json::from_value(serde_json::json!({
+        "id": "thr-1",
+        "originator": "codex_cli_rs"
+    }))
+    .unwrap();
+    assert_eq!(thread.originator.as_deref(), Some("codex_cli_rs"));
+
+    let bare: Thread = serde_json::from_value(serde_json::json!({"id": "thr-2"})).unwrap();
+    assert!(serde_json::to_value(bare)
+        .unwrap()
+        .get("originator")
+        .is_none());
+
+    let params = ThreadListParams {
+        originators: Some(vec!["codex_vscode".to_string()]),
+        ..ThreadListParams::default()
+    };
+    assert_eq!(
+        serde_json::to_value(params).unwrap(),
+        serde_json::json!({"originators": ["codex_vscode"]})
+    );
+}
+
+/// McpServerStatus.toolsError decodes the discovery failure message and is omitted when a catalog was returned.
+#[test]
+fn mcp_server_status_decodes_tools_error() {
+    let status: McpServerStatus = serde_json::from_value(serde_json::json!({
+        "authStatus": "unsupported",
+        "name": "broken",
+        "toolsError": "transport closed during tools/list"
+    }))
+    .unwrap();
+    assert_eq!(
+        status.tools_error.as_deref(),
+        Some("transport closed during tools/list")
+    );
+
+    let healthy: McpServerStatus = serde_json::from_value(serde_json::json!({
+        "authStatus": "unsupported",
+        "name": "ok"
+    }))
+    .unwrap();
+    assert!(serde_json::to_value(healthy)
+        .unwrap()
+        .get("toolsError")
+        .is_none());
 }
 
 /// MCP elicitation requests with the newer camelCase "openaiForm" mode decode to the OpenAiElicitationForm arm.

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -919,7 +919,7 @@ async fn test_account_read_family() {
     // assertion is "typed request goes out, typed response OR a well-formed
     // JSON-RPC error comes back" — not that this box's token can fetch
     // usage.
-    match client.account_rate_limits_read().await {
+    match client.account_rate_limits_read(Default::default()).await {
         Ok(_) => {}
         Err(codex_codes::Error::JsonRpc { code, .. }) => {
             assert_eq!(code, -32603, "unexpected rpc error class");

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -2111,7 +2111,14 @@
               "type": "string"
             },
             "params": {
-              "type": "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/v2/GetAccountRateLimitsParams"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
@@ -4272,7 +4279,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "cwd": {
-          "$ref": "#/definitions/v2/AbsolutePathBuf"
+          "$ref": "#/definitions/v2/LegacyAppPathString"
         },
         "environmentId": {
           "default": null,
@@ -7475,6 +7482,40 @@
       "AppToolsConfig": {
         "type": "object"
       },
+      "ApplicationNetworkRequirements": {
+        "properties": {
+          "domains": {
+            "additionalProperties": {
+              "$ref": "#/definitions/v2/NetworkDomainPermission"
+            },
+            "type": "object"
+          },
+          "enabled": {
+            "description": "When enabled, only explicitly allowed exact domains may be contacted.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "domains",
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "ApplicationRequirements": {
+        "properties": {
+          "network": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ApplicationNetworkRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
       "ApprovalsReviewer": {
         "description": "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to `user`. `auto_review` uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value `guardian_subagent` is accepted for compatibility.",
         "enum": [
@@ -10008,6 +10049,18 @@
         "title": "ConfigWriteResponse",
         "type": "object"
       },
+      "ConfigurationReasoning": {
+        "description": "Reasoning settings interpreted by the backend for the routed model.",
+        "properties": {
+          "effort": {
+            "$ref": "#/definitions/v2/ReasoningEffort"
+          }
+        },
+        "required": [
+          "effort"
+        ],
+        "type": "object"
+      },
       "ConfiguredHookHandler": {
         "oneOf": [
           {
@@ -12246,6 +12299,20 @@
         "title": "GetAccountParams",
         "type": "object"
       },
+      "GetAccountRateLimitsParams": {
+        "description": "Usage-read capabilities of the requesting client, never inferred from its experiment arm.",
+        "properties": {
+          "excludeResetCreditDetails": {
+            "description": "Skip the separate reset-credit detail lookup for background usage polls. The usage response still includes the available count; omitted/false preserves detailed reads.",
+            "type": "boolean"
+          },
+          "supportsLunaReserve": {
+            "description": "The client supports automatic Luna Reserve fallback. For eligible ChatGPT CLI users, allow the backend to record experiment exposure after ordinary usage is blocked.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "GetAccountRateLimitsResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -12253,6 +12320,13 @@
             "description": "Account associated with this usage snapshot, when supplied by the backend.",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "ordinaryUsageAllowed": {
+            "description": "Backend permission for ordinary included usage, validated against the active account. Null means unavailable; clients must not infer recovery from percentages or reset times.",
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -14507,6 +14581,13 @@
               "$ref": "#/definitions/v2/Tool"
             },
             "type": "object"
+          },
+          "toolsError": {
+            "description": "Tool discovery failed and no catalog was returned. Null when a catalog is returned, including cached or empty catalogs.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -15484,6 +15565,18 @@
           "compact"
         ],
         "type": "string"
+      },
+      "NullableGetAccountRateLimitsParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/v2/GetAccountRateLimitsParams"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Nullable_GetAccountRateLimitsParams"
       },
       "NullableGetAccountTokenUsageParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -17430,6 +17523,13 @@
               "null"
             ]
           },
+          "normalModelSlug": {
+            "description": "Normal model whose display name and reasoning options describe this quota alias.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "planType": {
             "anyOf": [
               {
@@ -18715,6 +18815,27 @@
             "type": "object"
           },
           {
+            "description": "A durable input control interpreted by the backend at its position in history.",
+            "properties": {
+              "reasoning": {
+                "$ref": "#/definitions/v2/ConfigurationReasoning"
+              },
+              "type": {
+                "enum": [
+                  "configuration_update"
+                ],
+                "title": "ConfigurationUpdateResponseItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reasoning",
+              "type"
+            ],
+            "title": "ConfigurationUpdateResponseItem",
+            "type": "object"
+          },
+          {
             "properties": {
               "type": {
                 "enum": [
@@ -18920,7 +19041,7 @@
               }
             ],
             "default": null,
-            "description": "Where to run the review: inline (default) on the current thread or detached on a new thread (returned in `reviewThreadId`)."
+            "description": "Where to run the review: inline (default) on the current thread or detached on a new thread (returned in `reviewThreadId`). Detached delivery is deprecated and emits `deprecationNotice`. Use `thread/start` followed by an inline review for a separate review thread."
           },
           "target": {
             "$ref": "#/definitions/v2/ReviewTarget"
@@ -20225,6 +20346,13 @@
               "null"
             ]
           },
+          "originator": {
+            "description": "Originator recorded when the thread was created, independent of its current client or executor. Null when the recorded originator is unavailable.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "parentThreadId": {
             "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
             "type": [
@@ -20471,6 +20599,29 @@
           "threadId"
         ],
         "title": "ThreadDeletedNotification",
+        "type": "object"
+      },
+      "ThreadEnvironment": {
+        "description": "An environment selected by a loaded thread, independent of connection status.",
+        "properties": {
+          "cwd": {
+            "$ref": "#/definitions/v2/LegacyAppPathString"
+          },
+          "environmentId": {
+            "type": "string"
+          },
+          "runtimeWorkspaceRoots": {
+            "items": {
+              "$ref": "#/definitions/v2/LegacyAppPathString"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cwd",
+          "environmentId",
+          "runtimeWorkspaceRoots"
+        ],
         "type": "object"
       },
       "ThreadExtra": {
@@ -21885,6 +22036,16 @@
           },
           "modelProviders": {
             "description": "Optional provider filter; when set, only sessions recorded under these providers are returned. When present but empty, includes all providers.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "originators": {
+            "description": "Optional originator allowlist, matching any supplied value exactly. Supported by hosted backends only; the local app-server rejects a nonempty list. Omitted or empty lists leave originators unrestricted.",
             "items": {
               "type": "string"
             },

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -966,6 +966,40 @@
     "AppToolsConfig": {
       "type": "object"
     },
+    "ApplicationNetworkRequirements": {
+      "properties": {
+        "domains": {
+          "additionalProperties": {
+            "$ref": "#/definitions/NetworkDomainPermission"
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "description": "When enabled, only explicitly allowed exact domains may be contacted.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "domains",
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "ApplicationRequirements": {
+      "properties": {
+        "network": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApplicationNetworkRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ApprovalsReviewer": {
       "description": "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to `user`. `auto_review` uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value `guardian_subagent` is accepted for compatibility.",
       "enum": [
@@ -3601,7 +3635,14 @@
               "type": "string"
             },
             "params": {
-              "type": "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/GetAccountRateLimitsParams"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
@@ -5906,6 +5947,18 @@
         "version"
       ],
       "title": "ConfigWriteResponse",
+      "type": "object"
+    },
+    "ConfigurationReasoning": {
+      "description": "Reasoning settings interpreted by the backend for the routed model.",
+      "properties": {
+        "effort": {
+          "$ref": "#/definitions/ReasoningEffort"
+        }
+      },
+      "required": [
+        "effort"
+      ],
       "type": "object"
     },
     "ConfiguredHookHandler": {
@@ -8257,6 +8310,20 @@
       "title": "GetAccountParams",
       "type": "object"
     },
+    "GetAccountRateLimitsParams": {
+      "description": "Usage-read capabilities of the requesting client, never inferred from its experiment arm.",
+      "properties": {
+        "excludeResetCreditDetails": {
+          "description": "Skip the separate reset-credit detail lookup for background usage polls. The usage response still includes the available count; omitted/false preserves detailed reads.",
+          "type": "boolean"
+        },
+        "supportsLunaReserve": {
+          "description": "The client supports automatic Luna Reserve fallback. For eligible ChatGPT CLI users, allow the backend to record experiment exposure after ordinary usage is blocked.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "GetAccountRateLimitsResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -8264,6 +8331,13 @@
           "description": "Account associated with this usage snapshot, when supplied by the backend.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "ordinaryUsageAllowed": {
+          "description": "Backend permission for ordinary included usage, validated against the active account. Null means unavailable; clients must not infer recovery from percentages or reset times.",
+          "type": [
+            "boolean",
             "null"
           ]
         },
@@ -10579,6 +10653,13 @@
             "$ref": "#/definitions/Tool"
           },
           "type": "object"
+        },
+        "toolsError": {
+          "description": "Tool discovery failed and no catalog was returned. Null when a catalog is returned, including cached or empty catalogs.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -11556,6 +11637,18 @@
         "compact"
       ],
       "type": "string"
+    },
+    "NullableGetAccountRateLimitsParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GetAccountRateLimitsParams"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Nullable_GetAccountRateLimitsParams"
     },
     "NullableGetAccountTokenUsageParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -13502,6 +13595,13 @@
             "null"
           ]
         },
+        "normalModelSlug": {
+          "description": "Normal model whose display name and reasoning options describe this quota alias.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "planType": {
           "anyOf": [
             {
@@ -14787,6 +14887,27 @@
           "type": "object"
         },
         {
+          "description": "A durable input control interpreted by the backend at its position in history.",
+          "properties": {
+            "reasoning": {
+              "$ref": "#/definitions/ConfigurationReasoning"
+            },
+            "type": {
+              "enum": [
+                "configuration_update"
+              ],
+              "title": "ConfigurationUpdateResponseItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "reasoning",
+            "type"
+          ],
+          "title": "ConfigurationUpdateResponseItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
               "enum": [
@@ -14992,7 +15113,7 @@
             }
           ],
           "default": null,
-          "description": "Where to run the review: inline (default) on the current thread or detached on a new thread (returned in `reviewThreadId`)."
+          "description": "Where to run the review: inline (default) on the current thread or detached on a new thread (returned in `reviewThreadId`). Detached delivery is deprecated and emits `deprecationNotice`. Use `thread/start` followed by an inline review for a separate review thread."
         },
         "target": {
           "$ref": "#/definitions/ReviewTarget"
@@ -17939,6 +18060,13 @@
             "null"
           ]
         },
+        "originator": {
+          "description": "Originator recorded when the thread was created, independent of its current client or executor. Null when the recorded originator is unavailable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "parentThreadId": {
           "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
           "type": [
@@ -18185,6 +18313,29 @@
         "threadId"
       ],
       "title": "ThreadDeletedNotification",
+      "type": "object"
+    },
+    "ThreadEnvironment": {
+      "description": "An environment selected by a loaded thread, independent of connection status.",
+      "properties": {
+        "cwd": {
+          "$ref": "#/definitions/LegacyAppPathString"
+        },
+        "environmentId": {
+          "type": "string"
+        },
+        "runtimeWorkspaceRoots": {
+          "items": {
+            "$ref": "#/definitions/LegacyAppPathString"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cwd",
+        "environmentId",
+        "runtimeWorkspaceRoots"
+      ],
       "type": "object"
     },
     "ThreadExtra": {
@@ -19599,6 +19750,16 @@
         },
         "modelProviders": {
           "description": "Optional provider filter; when set, only sessions recorded under these providers are returned. When present but empty, includes all providers.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "originators": {
+          "description": "Optional originator allowlist, matching any supplied value exactly. Supported by hosted backends only; the local app-server rejects a nonempty list. Omitted or empty lists leave originators unrestricted.",
           "items": {
             "type": "string"
           },

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -260,7 +260,10 @@ async fn account_read_family(reporter: &Reporter) {
         for (name, result) in [
             (
                 "rateLimits",
-                client.account_rate_limits_read().await.map(|_| ()),
+                client
+                    .account_rate_limits_read(Default::default())
+                    .await
+                    .map(|_| ()),
             ),
             ("usage", client.account_usage_read().await.map(|_| ())),
         ] {


### PR DESCRIPTION
Fixes #359.

## Drift assessed

The nightly check flagged 6 new definitions and 6 changed bodies in the v2 schema, plus 3 changed in the full bundle. Only codex-codes drifted; the claude, muse, opencode, and antigravity local drift checks are all clean.

## Modeled

- `GetAccountRateLimitsParams` (`supportsLunaReserve`, `excludeResetCreditDetails`). Both flags omit when false, so the default still serializes as `{}`.
- `GetAccountRateLimitsResponse.ordinaryUsageAllowed`
- `RateLimitSnapshot.normalModelSlug`
- `McpServerStatus.toolsError`
- `Thread.originator` and `ThreadListParams.originators`
- `PermissionsRequestApprovalParams.cwd` moves to `LegacyAppPathString` (both transparent string newtypes, wire unchanged)

## Breaking

- `AsyncClient::account_rate_limits_read` now takes `GetAccountRateLimitsParams`. `wirecheck` and the live tests pass `Default::default()`.

## Not modeled (noted in CHANGELOG)

- `ThreadEnvironment` / `ApplicationRequirements` are unreachable from any published method (they back experimental upstream fields).
- The `configuration_update` `ResponseItem` variant; the raw `ResponseItem` stream is not typed by this crate.

## Verification

- `cargo test -p codex-codes`: 88 unit + 27 integration pass (4 new tests)
- `cargo run --example schema_coverage`: 100% of modeled methods validate
- `scripts/check_codex_schema_drift.py`: both snapshots JSON-identical to upstream
- `cargo clippy --workspace --all-targets -- -D warnings` clean