### PR TITLE
codex-codes 0.151.4: GPT-6-Astra and Daybreak models in CodexModel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.3"
+version = "0.151.4"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.259`, tested against Claude CLI `2.1.259`.
-- **`codex-codes`** — currently `codex-codes 0.151.3`, tested against Codex CLI `0.151.0`.
+- **`codex-codes`** — currently `codex-codes 0.151.4`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.4] - 2026-09-04
+
+### Added
+
+- `CodexModel`: `Gpt6Astra` (`gpt-6-astra`, first GPT-6-family catalog
+  entry, 272k context) and the cyber-access pair `DaybreakBlue` /
+  `DaybreakRed` (`gpt-daybreak-{blue,red}-latest`; Red carries a 372k
+  context) from `openai/codex@main`'s models-manager catalog.
+  Live-probed: the backend recognizes `gpt-6-astra` but rejects it for
+  ChatGPT-plan auth — server-side gated, noted on the variant.
+
 ## [0.151.3] - 2026-09-04
 
 Resnapshots vs `openai/codex@main` (fixes #359).

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.3"
+version = "0.151.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/models.rs
+++ b/codex-codes/src/models.rs
@@ -16,6 +16,17 @@ use std::fmt;
 /// A model slug accepted by the Codex CLI and app-server.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CodexModel {
+    /// GPT-6-Astra (`gpt-6-astra`) — first GPT-6-family model in the
+    /// catalog (272k context). Live-probed 2026-09-04: the backend
+    /// recognizes the slug but rejects it for ChatGPT-plan auth
+    /// ("not supported when using Codex with a ChatGPT account").
+    Gpt6Astra,
+    /// Daybreak Blue (`gpt-daybreak-blue-latest`) — the cyber-access
+    /// program models (see `CyberAccessProgram`); server-side gated.
+    DaybreakBlue,
+    /// Daybreak Red (`gpt-daybreak-red-latest`) — cyber-access program,
+    /// 372k context; server-side gated.
+    DaybreakRed,
     /// GPT-5.6-Sol (`gpt-5.6-sol`).
     Gpt56Sol,
     /// GPT-5.6-Terra (`gpt-5.6-terra`).
@@ -42,6 +53,9 @@ impl CodexModel {
     /// The slug to pass to `codex -m` / `ThreadStartParams.model`.
     pub fn cli_arg(&self) -> &str {
         match self {
+            Self::Gpt6Astra => "gpt-6-astra",
+            Self::DaybreakBlue => "gpt-daybreak-blue-latest",
+            Self::DaybreakRed => "gpt-daybreak-red-latest",
             Self::Gpt56Sol => "gpt-5.6-sol",
             Self::Gpt56Terra => "gpt-5.6-terra",
             Self::Gpt56Luna => "gpt-5.6-luna",
@@ -63,6 +77,9 @@ impl CodexModel {
     /// Human-friendly display name, matching the catalog's `display_name`.
     pub fn display_name(&self) -> &str {
         match self {
+            Self::Gpt6Astra => "GPT-6-Astra",
+            Self::DaybreakBlue => "Daybreak Blue",
+            Self::DaybreakRed => "Daybreak Red",
             Self::Gpt56Sol => "GPT-5.6-Sol",
             Self::Gpt56Terra => "GPT-5.6-Terra",
             Self::Gpt56Luna => "GPT-5.6-Luna",
@@ -78,6 +95,9 @@ impl CodexModel {
     /// Every model known to this version of the crate.
     pub fn known() -> &'static [CodexModel] {
         &[
+            Self::Gpt6Astra,
+            Self::DaybreakBlue,
+            Self::DaybreakRed,
             Self::Gpt56Sol,
             Self::Gpt56Terra,
             Self::Gpt56Luna,
@@ -99,6 +119,9 @@ impl fmt::Display for CodexModel {
 impl From<&str> for CodexModel {
     fn from(s: &str) -> Self {
         match s {
+            "gpt-6-astra" => Self::Gpt6Astra,
+            "gpt-daybreak-blue-latest" => Self::DaybreakBlue,
+            "gpt-daybreak-red-latest" => Self::DaybreakRed,
             "gpt-5.6-sol" => Self::Gpt56Sol,
             "gpt-5.6-terra" => Self::Gpt56Terra,
             "gpt-5.6-luna" => Self::Gpt56Luna,


### PR DESCRIPTION
Answers Matt's model-picker question: `gpt-6-astra` was NOT in `CodexModel` (the enum topped out at the 5.6 family). Now it is, along with the two other catalog entries we were missing.

From `openai/codex@main`'s `models-manager/models.json` (reference clone re-pulled today):
- **`Gpt6Astra`** (`gpt-6-astra`, GPT-6-Astra) — first GPT-6-family entry, 272k context
- **`DaybreakBlue`** / **`DaybreakRed`** (`gpt-daybreak-{blue,red}-latest`) — the cyber-access program models matching the `CyberAccessProgram` enum from the 0.147.4 drift; Red carries a 372k context

Live probe against the real app-server: the backend **recognizes `gpt-6-astra` but rejects it for ChatGPT-plan auth** ("The 'gpt-6-astra' model is not supported when using Codex with a ChatGPT account") — server-side gating, documented on the variant so picker consumers know why selection may fail.

Round-trip tests cover the new variants via `CodexModel::known()`. Version 0.151.3 → 0.151.4 (crate-side patch; tested pin stays 0.151.0). Auto-publishes on merge; agent-portal's launcher picker gets the new entries on its next dep bump.

No muse-style "emu" model exists anywhere in the catalog — that was a typo for "enum" 🙂