### PR TITLE
claude-codes 2.1.261: model 2.1.259 → 2.1.261 stream-json drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.259"
+version = "2.1.261"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.259`, tested against Claude CLI `2.1.259`.
+- **`claude-codes`** — currently `claude-codes 2.1.261`, tested against Claude CLI `2.1.261`.
 - **`codex-codes`** — currently `codex-codes 0.151.4`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.261] - 2026-09-05
+
+Re-baseline against Claude CLI **2.1.261**: the tested pin (`TESTED_VERSION`,
+both README `Tested against:` lines) and the crate version move to 2.1.261.
+Models the 2.1.259 → 2.1.261 stream-json drift (all additive) reported by the
+nightly drift check on issue #361, plus the one field 2.1.261 added on top of
+the 2.1.260 report.
+
+### Added
+
+- `SystemSubtype::CloudSessionDelta` / `CloudSessionDeltaMessage` /
+  `KnownSystemEvent::CloudSessionDelta` — the new `system/cloud_session_delta`
+  frame the headless client of a cloud-hosted session writes when the
+  session's status changes between two inits (`seq`, `changed`, and the
+  whole `cloud_session` block as raw JSON, matching `InitMessage`).
+- `AssistantMessage.narration_block_indexes` — indexes into
+  `message.content` of the thinking blocks the server tagged as narration.
+- `ResultMessage.first_content_frame_ms`, `.first_stream_post_ms`,
+  `.first_stream_post_ack_ms`, `.first_stream_post_wall_ms` — stream-timing
+  instrumentation on `result/success`.
+- `ApiRetryMessage.no_response` (`ApiRetryNoResponse`) — present only on
+  first-byte-timeout retries, with how long the attempt waited and how long
+  the retry will wait.
+- `ThinkingTokensMessage.user_message_uuid` — the client uuid of the send the
+  thinking progress belongs to.
+
+### Fixed
+
+- `scripts/extract_claude_sdk_schemas.py` now resolves schema references only
+  inside the bundle chunk that holds the SDK output union. On 2.1.261 the
+  assistant schema calls a plain `se()` helper (`z.unknown()`) whose only
+  lazy definition lives in another chunk; following it crawled that chunk's
+  module graph and inflated the extraction to 667 "schemas" (and the drift
+  report to 89 phantom wire labels). The 2.1.239 and 2.1.259 extractions are
+  byte-identical before and after.
+
 ## [2.1.259] - 2026-09-03
 
 Re-baseline against Claude CLI **2.1.259**: the full live integration suite

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.259"
+version = "2.1.261"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.259
+**Tested against:** Claude CLI 2.1.261
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -44,6 +44,7 @@ pub enum SystemSubtype {
     CodeChangePublished,
     VcsStateChanged,
     FeedbackDraftQueued,
+    CloudSessionDelta,
     /// A subtype not yet known to this version of the crate.
     Unknown(String),
 }
@@ -82,6 +83,7 @@ impl SystemSubtype {
             Self::CodeChangePublished => "code_change_published",
             Self::VcsStateChanged => "vcs_state_changed",
             Self::FeedbackDraftQueued => "feedback_draft_queued",
+            Self::CloudSessionDelta => "cloud_session_delta",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -127,6 +129,7 @@ impl From<&str> for SystemSubtype {
             "code_change_published" => Self::CodeChangePublished,
             "vcs_state_changed" => Self::VcsStateChanged,
             "feedback_draft_queued" => Self::FeedbackDraftQueued,
+            "cloud_session_delta" => Self::CloudSessionDelta,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -1044,6 +1047,19 @@ impl SystemMessage {
         serde_json::from_value(self.data.clone()).ok()
     }
 
+    /// Check if this is a cloud_session_delta message.
+    pub fn is_cloud_session_delta(&self) -> bool {
+        self.subtype == SystemSubtype::CloudSessionDelta
+    }
+
+    /// Try to parse as a cloud_session_delta message.
+    pub fn as_cloud_session_delta(&self) -> Option<CloudSessionDeltaMessage> {
+        if self.subtype != SystemSubtype::CloudSessionDelta {
+            return None;
+        }
+        serde_json::from_value(self.data.clone()).ok()
+    }
+
     /// Parse any typed system subtype known to this crate version.
     pub fn as_known_system_event(&self) -> Option<KnownSystemEvent> {
         macro_rules! parse {
@@ -1105,6 +1121,9 @@ impl SystemMessage {
             SystemSubtype::VcsStateChanged => parse!(VcsStateChanged, VcsStateChangedMessage),
             SystemSubtype::FeedbackDraftQueued => {
                 parse!(FeedbackDraftQueued, FeedbackDraftQueuedMessage)
+            }
+            SystemSubtype::CloudSessionDelta => {
+                parse!(CloudSessionDelta, CloudSessionDeltaMessage)
             }
             SystemSubtype::Unknown(_) => None,
         }
@@ -1182,6 +1201,9 @@ impl SystemMessage {
             SystemSubtype::FeedbackDraftQueued => {
                 reserialize(parse_system::<FeedbackDraftQueuedMessage>(self))
             }
+            SystemSubtype::CloudSessionDelta => {
+                reserialize(parse_system::<CloudSessionDeltaMessage>(self))
+            }
             SystemSubtype::Unknown(_) => None,
         }
     }
@@ -1230,6 +1252,7 @@ pub enum KnownSystemEvent {
     CodeChangePublished(CodeChangePublishedMessage),
     VcsStateChanged(VcsStateChangedMessage),
     FeedbackDraftQueued(FeedbackDraftQueuedMessage),
+    CloudSessionDelta(CloudSessionDeltaMessage),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1239,10 +1262,26 @@ pub struct ApiRetryMessage {
     pub retry_delay_ms: u64,
     pub error_status: Option<u16>,
     pub error: String,
+    /// Present only when the API sent no response headers within the
+    /// first-byte window (`CLAUDE_STREAM_FIRST_BYTE_TIMEOUT_MS`). For this
+    /// cause `max_retries` is its own cap (normally one retry), not the
+    /// session budget (CLI 2.1.261+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_response: Option<ApiRetryNoResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+}
+
+/// Timing of a first-byte-timeout retry, carried as
+/// [`ApiRetryMessage::no_response`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiRetryNoResponse {
+    /// How long the failed attempt waited for response headers.
+    pub waited_ms: u64,
+    /// How long the retry will wait for them.
+    pub retry_wait_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2108,6 +2147,14 @@ pub struct ThinkingTokensMessage {
     pub estimated_tokens: u64,
     /// Increase in the estimate since the previous `thinking_tokens` event.
     pub estimated_tokens_delta: u64,
+    /// Client uuid of the user message that triggered this turn, stamped on
+    /// every `thinking_tokens` frame of a headless turn so a consumer can
+    /// attribute thinking progress to the send it answers before any reply
+    /// frame arrives. Absent on synthetic/scheduled (meta) turns, on turns
+    /// without a client uuid, on Remote Control sessions, and from CLIs
+    /// before 2.1.261.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message_uuid: Option<String>,
     pub uuid: String,
 }
 
@@ -2365,6 +2412,33 @@ pub struct FeedbackDraftQueuedMessage {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// `system/cloud_session_delta` — written only by the headless stream-json
+/// client of a cloud-hosted session (the same client that puts
+/// `cloud_session` on its init frames): the session's status changed between
+/// two inits. Only after the first init; at most a few per second; none when
+/// nothing differs. An init is always a complete snapshot, so a host that
+/// (re)attaches resynchronises from the first init it reads and applies
+/// these on top. Display-only (CLI 2.1.260+).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSessionDeltaMessage {
+    /// Rises by one with each of these frames this client writes (1 for the
+    /// first); never reset by an init. A reader keeps the highest it has
+    /// applied and drops a lower one.
+    pub seq: u64,
+    /// The top-level keys of `cloud_session` whose value differs from the
+    /// last block this client wrote, e.g. `["serving"]`; never empty. A hint
+    /// for what to redraw — the block is complete either way.
+    pub changed: Vec<String>,
+    /// The whole block exactly as the next init would carry it (see
+    /// [`InitMessage::cloud_session`]): replace the held copy, do not merge.
+    /// Stored as raw JSON (the shape is internal and evolving).
+    pub cloud_session: Value,
+    pub uuid: String,
+    pub session_id: String,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
 /// `{id, name}` of an original `Batch*` tool_use block, carried in
 /// [`AssistantMessage::batch_tool_uses`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2554,6 +2628,16 @@ pub struct AssistantMessage {
     /// (CLI 2.1.259+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_command_source: Option<String>,
+    /// Ascending zero-based indexes into `message.content` of the thinking
+    /// blocks whose signature the server tagged as narration (server
+    /// summaries of the prose between tool calls, not the model's own
+    /// reasoning), so a renderer can label them as summaries without decoding
+    /// the signature envelope. Fail-closed: an unparseable or legacy
+    /// signature is not listed. Omitted when the frame has no such block and
+    /// by CLIs before 2.1.260; treat unlisted thinking blocks as ordinary
+    /// thinking. Wrapper-level sibling — never inside `message.content`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub narration_block_indexes: Vec<usize>,
     /// Structured twin of the `/context` report, carried on the synthetic
     /// assistant message that delivers the markdown table. Present only on
     /// `/context` results from CLIs new enough to attach it (2.1.239+).
@@ -3485,6 +3569,47 @@ mod tests {
             panic!("expected FeedbackDraftQueued event");
         };
         assert_eq!(known.title, "Tool output was truncated");
+        assert_eq!(
+            sys.typed_value().expect("typed value")["future_field"],
+            "preserved"
+        );
+    }
+
+    #[test]
+    fn test_cloud_session_delta_fully_wrapped() {
+        use super::{KnownSystemEvent, SystemSubtype};
+        use serde_json::Value;
+
+        let raw: Value = serde_json::from_str(
+            r#"{
+            "type":"system","subtype":"cloud_session_delta",
+            "seq":3,"changed":["serving","connection"],
+            "cloud_session":{"id":"session_abc","view_url":"https://example.invalid/s/abc",
+                "serving":{"state":"on"},"connection":{"state":"live"}},
+            "uuid":"u1","session_id":"s1","future_field":"preserved"
+        }"#,
+        )
+        .unwrap();
+        crate::io::assert_fully_wrapped(&raw);
+
+        let output: ClaudeOutput = serde_json::from_value(raw).unwrap();
+        let ClaudeOutput::System(sys) = output else {
+            panic!("expected System");
+        };
+        assert_eq!(sys.subtype, SystemSubtype::CloudSessionDelta);
+        assert!(sys.is_cloud_session_delta());
+        assert!(!sys.is_feedback_draft_queued());
+
+        let direct = sys.as_cloud_session_delta().expect("direct typed accessor");
+        assert_eq!(direct.seq, 3);
+        assert_eq!(direct.changed, vec!["serving", "connection"]);
+        assert_eq!(direct.cloud_session["id"], "session_abc");
+        assert_eq!(direct.extra["future_field"], "preserved");
+
+        let Some(KnownSystemEvent::CloudSessionDelta(known)) = sys.as_known_system_event() else {
+            panic!("expected CloudSessionDelta event");
+        };
+        assert_eq!(known.session_id, "s1");
         assert_eq!(
             sys.typed_value().expect("typed value")["future_field"],
             "preserved"

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -39,6 +39,26 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_sent_wall_ms: Option<f64>,
 
+    /// Time until the first content frame of the stream arrived, in
+    /// milliseconds (CLI 2.1.260+ timing instrumentation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_content_frame_ms: Option<u64>,
+
+    /// Time until the first stream POST was issued, in milliseconds
+    /// (CLI 2.1.260+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_stream_post_ms: Option<u64>,
+
+    /// Time until the first stream POST was acknowledged, in milliseconds
+    /// (CLI 2.1.260+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_stream_post_ack_ms: Option<u64>,
+
+    /// Wall-clock epoch milliseconds when the first stream POST was issued
+    /// (fractional; CLI 2.1.260+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_stream_post_wall_ms: Option<f64>,
+
     /// Wire uuid of the user message this result answers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_message_uuid: Option<String>,

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.239**
+//! Current tested version: **2.1.261**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!
@@ -163,22 +163,23 @@ pub use io::{
 
 // System message and assistant message types
 pub use io::{
-    ApiKeySource, ApiRetryMessage, AssistantErrorKind, BackgroundTaskInfo,
-    BackgroundTasksChangedMessage, BatchToolUse, CodeChangePublishedMessage, CommandInfo,
-    CommandsChangedMessage, CompactBoundaryMessage, CompactMetadata, CompactionTrigger,
-    ContextAgent, ContextCategory, ContextMcpTool, ContextMemoryFile, ContextOverLimit,
-    ContextSkill, ContextUsage, ControlRequestProgressMessage, ElicitationCompleteMessage,
-    FailedPersistedFile, FeedbackDraftQueuedMessage, FilesPersistedMessage, HookProgressMessage,
-    HookResponseMessage, HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode,
-    KnownSystemEvent, LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths,
-    MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey,
-    MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
-    NotificationMessage, OutputStyle, PermissionDeniedMessage, PersistedFile, PluginDiagnostic,
-    PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, RefusalFallbackScope,
-    StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage,
-    SystemSubtype, TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage,
-    TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta,
-    ToolUseMeta, VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
+    ApiKeySource, ApiRetryMessage, ApiRetryNoResponse, AssistantErrorKind, BackgroundTaskInfo,
+    BackgroundTasksChangedMessage, BatchToolUse, CloudSessionDeltaMessage,
+    CodeChangePublishedMessage, CommandInfo, CommandsChangedMessage, CompactBoundaryMessage,
+    CompactMetadata, CompactionTrigger, ContextAgent, ContextCategory, ContextMcpTool,
+    ContextMemoryFile, ContextOverLimit, ContextSkill, ContextUsage, ControlRequestProgressMessage,
+    ElicitationCompleteMessage, FailedPersistedFile, FeedbackDraftQueuedMessage,
+    FilesPersistedMessage, HookProgressMessage, HookResponseMessage, HookStartedMessage,
+    InformationalMessage, InitMessage, InitPermissionMode, KnownSystemEvent,
+    LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths, MemoryRecallItem,
+    MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey, MirrorErrorMessage,
+    ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage, NotificationMessage, OutputStyle,
+    PermissionDeniedMessage, PersistedFile, PluginDiagnostic, PluginInfo, PluginInstallMessage,
+    PreservedMessages, PreservedSegment, RefusalFallbackScope, StatusMessage, StatusMessageStatus,
+    StopReason, SummarizeMetadata, SystemMessage, SystemSubtype, TaskNotificationMessage,
+    TaskPatch, TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUpdatedMessage,
+    TaskUsage, ThinkingTokensMessage, ToolResultMeta, ToolUseMeta, VcsMutationKind,
+    VcsStateChangedMessage, WorkerShuttingDownMessage,
 };
 
 // Additional top-level output message wrappers

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.259";
+const TESTED_VERSION: &str = "2.1.261";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schema_2_1_261_tests.rs
+++ b/claude-codes/tests/schema_2_1_261_tests.rs
@@ -1,0 +1,229 @@
+//! Coverage for the CLI 2.1.261 stream-json additive drift.
+//!
+//! 2.1.259 → 2.1.261 added one `system` subtype (`cloud_session_delta`) and
+//! top-level fields to four wire types without removing any (see the drift
+//! report on issue #361). Each frame below carries the new fields and is
+//! asserted **fully wrapped** — the typed model captures every wire field
+//! with nothing left in an untyped escape hatch.
+
+use claude_codes::{assert_fully_wrapped, ClaudeOutput, KnownSystemEvent, SystemSubtype};
+use serde_json::json;
+
+/// Pins that an `assistant` frame's 2.1.260 `narration_block_indexes`
+/// wrapper sibling round-trips without loss and defaults to empty.
+#[test]
+fn assistant_carries_narration_block_indexes() {
+    let frame = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [
+                {"type": "thinking", "thinking": "", "signature": "sig-narration"},
+                {"type": "text", "text": "done"}
+            ],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1",
+        "uuid": "u1",
+        "parent_tool_use_id": null,
+        "narration_block_indexes": [0]
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.narration_block_indexes, vec![0]);
+
+    let reserialized = serde_json::to_string(&msg).unwrap();
+    assert!(reserialized.contains("\"narration_block_indexes\":[0]"));
+
+    let old = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1"
+    });
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(old).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert!(msg.narration_block_indexes.is_empty());
+    let reserialized = serde_json::to_string(&msg).unwrap();
+    assert!(!reserialized.contains("narration_block_indexes"));
+}
+
+/// Pins that a `result/success` frame's 2.1.260 stream-timing fields
+/// (`first_content_frame_ms`, `first_stream_post_ms`,
+/// `first_stream_post_ack_ms`, `first_stream_post_wall_ms`) round-trip.
+#[test]
+fn result_carries_first_stream_post_timings() {
+    let frame = json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "duration_ms": 1200,
+        "duration_api_ms": 900,
+        "num_turns": 1,
+        "result": "ok",
+        "session_id": "s1",
+        "total_cost_usd": 0.01,
+        "usage": {"input_tokens": 1, "output_tokens": 2},
+        "permission_denials": [],
+        "uuid": "u1",
+        "ttft_ms": 300,
+        "request_sent_wall_ms": 1753212345678.25,
+        "first_content_frame_ms": 310,
+        "first_stream_post_ms": 12,
+        "first_stream_post_ack_ms": 40,
+        "first_stream_post_wall_ms": 1753212345690.5
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Result(res) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected result");
+    };
+    assert_eq!(res.first_content_frame_ms, Some(310));
+    assert_eq!(res.first_stream_post_ms, Some(12));
+    assert_eq!(res.first_stream_post_ack_ms, Some(40));
+    assert_eq!(res.first_stream_post_wall_ms, Some(1753212345690.5));
+
+    let reserialized = serde_json::to_string(&res).unwrap();
+    assert!(reserialized.contains("\"first_content_frame_ms\":310"));
+    assert!(reserialized.contains("\"first_stream_post_wall_ms\":1753212345690.5"));
+}
+
+/// Pins that a `system/api_retry` frame's 2.1.261 `no_response` block
+/// (first-byte-timeout retries) round-trips, and is absent otherwise.
+#[test]
+fn api_retry_carries_no_response_timing() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 1,
+        "max_retries": 1,
+        "retry_delay_ms": 0,
+        "error_status": null,
+        "error": "no response headers within 30000ms",
+        "no_response": {"waited_ms": 30000, "retry_wait_ms": 60000},
+        "uuid": "u1",
+        "session_id": "s1"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected system");
+    };
+    assert_eq!(sys.subtype, SystemSubtype::ApiRetry);
+    let Some(KnownSystemEvent::ApiRetry(retry)) = sys.as_known_system_event() else {
+        panic!("expected ApiRetry event");
+    };
+    let no_response = retry.no_response.expect("no_response present");
+    assert_eq!(no_response.waited_ms, 30000);
+    assert_eq!(no_response.retry_wait_ms, 60000);
+
+    let ordinary = json!({
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 2,
+        "max_retries": 10,
+        "retry_delay_ms": 2000,
+        "error_status": 529,
+        "error": "overloaded",
+        "uuid": "u2",
+        "session_id": "s1"
+    });
+    let ClaudeOutput::System(sys) = serde_json::from_value(ordinary).unwrap() else {
+        panic!("expected system");
+    };
+    let Some(KnownSystemEvent::ApiRetry(retry)) = sys.as_known_system_event() else {
+        panic!("expected ApiRetry event");
+    };
+    assert!(retry.no_response.is_none());
+    assert!(!serde_json::to_string(&retry)
+        .unwrap()
+        .contains("no_response"));
+}
+
+/// Pins that a `system/thinking_tokens` frame's 2.1.261 `user_message_uuid`
+/// send-binding key round-trips.
+#[test]
+fn thinking_tokens_carries_user_message_uuid() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "thinking_tokens",
+        "estimated_tokens": 420,
+        "estimated_tokens_delta": 20,
+        "user_message_uuid": "um-1",
+        "uuid": "u1",
+        "session_id": "s1"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected system");
+    };
+    let Some(KnownSystemEvent::ThinkingTokens(tokens)) = sys.as_known_system_event() else {
+        panic!("expected ThinkingTokens event");
+    };
+    assert_eq!(tokens.user_message_uuid.as_deref(), Some("um-1"));
+    assert_eq!(tokens.estimated_tokens, 420);
+}
+
+/// Pins the new 2.1.260 `system/cloud_session_delta` subtype: a typed view,
+/// a `KnownSystemEvent` variant, and the raw `cloud_session` block held
+/// verbatim (its shape is internal and evolving).
+#[test]
+fn cloud_session_delta_is_a_known_system_event() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "cloud_session_delta",
+        "seq": 1,
+        "changed": ["serving"],
+        "cloud_session": {
+            "id": "session_abc",
+            "view_url": "https://example.invalid/s/abc",
+            "device": {"status": "bound", "device_id": "dev-1"},
+            "serving": {"state": "on", "policy": "parity"}
+        },
+        "uuid": "u1",
+        "session_id": "s1"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected system");
+    };
+    assert_eq!(sys.subtype, SystemSubtype::CloudSessionDelta);
+    assert_eq!(sys.subtype.as_str(), "cloud_session_delta");
+
+    let delta = sys.as_cloud_session_delta().expect("typed view");
+    assert_eq!(delta.seq, 1);
+    assert_eq!(delta.changed, vec!["serving"]);
+    assert_eq!(delta.cloud_session["serving"]["state"], "on");
+
+    let Some(KnownSystemEvent::CloudSessionDelta(known)) = sys.as_known_system_event() else {
+        panic!("expected CloudSessionDelta event");
+    };
+    assert_eq!(known.cloud_session["id"], "session_abc");
+}

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -3,19 +3,20 @@
 # One line per wire label: `<type[/subtype]>: comma-separated top-level field keys`.
 # Minified schema names and nested/describe() detail are intentionally omitted;
 # see the header of check_claude_schema_drift.py for the comparison contract.
-# union_members: 43
+# union_members: 44
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, local_command_source, message, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_tool_inputs
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, local_command_source, message, narration_block_indexes, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_tool_inputs
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
 conversation_reset: new_conversation_id, session_id, type, uuid
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
 result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, first_content_frame_ms, first_stream_post_ack_ms, first_stream_post_ms, first_stream_post_wall_ms, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
 stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, user_message_uuid, user_message_uuids, uuid
-system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
+system/api_retry: attempt, error, error_status, max_retries, no_response, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
+system/cloud_session_delta: changed, cloud_session, seq, session_id, subtype, type, uuid
 system/code_change_published: action, branch, identifier, provider, repo, session_id, subtype, type, url, uuid
 system/commands_changed: commands, session_id, subtype, type, uuid
 system/compact_boundary: compact_metadata, logical_parent_uuid, session_id, subtype, type, uuid
@@ -42,7 +43,7 @@ system/task_notification: ambient, output_file, resource_links, session_id, skip
 system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
 system/task_started: ambient, description, is_backgrounded, prompt, session_id, skip_transcript, spawn_depth, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
 system/task_updated: patch, session_id, subtype, task_id, type, uuid
-system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
+system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, user_message_uuid, uuid
 system/vcs_state_changed: branch, cwd, kind, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid
 tool_progress: elapsed_time_seconds, heartbeat, parent_tool_use_id, session_id, subagent_retry, subagent_type, task_id, tool_name, tool_use_id, type, uuid

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -183,20 +183,42 @@ def discover_aliases(data: bytes) -> list[tuple[re.Match[bytes], WirePatterns]]:
     return out
 
 
-def index_definitions(data: bytes, pats: WirePatterns) -> dict[str, list[tuple[int, bytes]]]:
-    """One pass over the binary → {name: [(offset, body-bytes), ...]}.
+# Bun separates the bundled JS chunks with a `// @bun` banner. Minified names
+# are only unique within one chunk, so schema references are resolved inside
+# the chunk that holds the SDK output union.
+CHUNK_MARKER = b"// @bun"
+
+
+def chunk_bounds(data: bytes, offset: int) -> tuple[int, int]:
+    """`(start, end)` of the bundle chunk containing `offset`."""
+    lo = data.rfind(CHUNK_MARKER, 0, offset)
+    hi = data.find(CHUNK_MARKER, offset)
+    return (0 if lo < 0 else lo, len(data) if hi < 0 else hi)
+
+
+def index_definitions(
+    data: bytes, pats: WirePatterns, lo: int = 0, hi: int | None = None
+) -> dict[str, list[tuple[int, bytes]]]:
+    """One pass over `data[lo:hi]` → {name: [(offset, body-bytes), ...]}.
 
     Minified names collide across bundle modules, so each name maps to every
     candidate definition; callers pick the one nearest the union with
     [`pick_definition`]. Indexing once turns per-name full-binary scans into
     O(1) lookups — the difference between minutes and seconds on a ~250 MB ELF.
+
+    `lo`/`hi` bound the scan to one bundle chunk (see [`chunk_bounds`]). A
+    name that is a plain helper in the union's chunk (`se()` is `z.unknown()`
+    on CLI 2.1.261) can be a lazy schema in another chunk; resolving it there
+    crawled that chunk's whole module graph.
     """
+    if hi is None:
+        hi = len(data)
     idx: dict[str, list[tuple[int, bytes]]] = {}
-    for m in pats.def_start.finditer(data):
+    for m in pats.def_start.finditer(data, lo, hi):
         name = m.group(1).decode()
         start = m.start() + 1
-        nxt = pats.boundary.search(data, m.end())
-        end = nxt.start() + 1 if nxt else m.end() + 20_000
+        nxt = pats.boundary.search(data, m.end(), hi)
+        end = nxt.start() + 1 if nxt else min(m.end() + 20_000, hi)
         idx.setdefault(name, []).append((start, data[start:end]))
     return idx
 
@@ -233,7 +255,7 @@ def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> E
     union_text = union.group(0).decode()
     members = REF_CALL.findall(union_text)
 
-    idx = index_definitions(data, pats)
+    idx = index_definitions(data, pats, *chunk_bounds(data, union.start()))
     results: list[tuple[str, str, str]] = []
     unresolved: list[str] = []
     seen: set[str] = set()
@@ -245,7 +267,7 @@ def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> E
         seen.add(name)
         body = pick_definition(idx.get(name, []), union.start())
         if body is None:
-            # Not defined under the schema wrapper anywhere in the bundle —
+            # Not defined under the schema wrapper anywhere in this chunk —
             # a module-initializer thunk (`NAME=S(()=>{...})`) or helper
             # function whose call site happens to match the `ref()` shape,
             # not a schema. Verified empirically: every such name in CLI
@@ -308,7 +330,7 @@ def main() -> None:
     )
     if extraction.unresolved:
         print(
-            "# non-schema refs skipped (no lazy definition anywhere): "
+            "# non-schema refs skipped (no lazy definition in the union chunk): "
             + ", ".join(extraction.unresolved),
             file=sys.stderr,
         )


### PR DESCRIPTION
Closes #361.

## Drift (all additive)

The nightly check ran against CLI 2.1.260; the locally installed 2.1.261 adds one more field. Modelled:

| Wire | Crate |
|---|---|
| new `system/cloud_session_delta` | `SystemSubtype::CloudSessionDelta`, `CloudSessionDeltaMessage`, `KnownSystemEvent::CloudSessionDelta` (`cloud_session` kept as raw JSON, matching `InitMessage`) |
| `assistant.narration_block_indexes` | `AssistantMessage.narration_block_indexes: Vec<usize>` |
| `result/success.first_content_frame_ms`, `.first_stream_post_ms`, `.first_stream_post_ack_ms`, `.first_stream_post_wall_ms` | `ResultMessage` optionals |
| `system/api_retry.no_response` (2.1.261) | `ApiRetryMessage.no_response: Option<ApiRetryNoResponse>` |
| `system/thinking_tokens.user_message_uuid` (2.1.261) | `ThinkingTokensMessage.user_message_uuid` |

A deep (all-nesting-levels) key diff of the 2.1.259 vs 2.1.261 extractions shows nothing else; the only other change is `system/init.cloud_session` moving to a named function schema, which the crate already stores as raw JSON.

## Extractor fix

`scripts/extract_claude_sdk_schemas.py` now resolves schema references only inside the `// @bun` chunk that holds the SDK output union. On 2.1.261 the assistant schema calls a plain `se()` helper (`z.unknown()`) whose only lazy definition lives in another chunk; following it crawled that chunk's module graph, inflating the extraction to 667 "schemas" and the local drift report to 89 phantom wire labels. The 2.1.239 and 2.1.259 extractions are byte-identical before and after; 2.1.261 now yields 70 schemas / 44 union members.

## Verification

- `cargo test -p claude-codes`: 282 tests pass (new `tests/schema_2_1_261_tests.rs` pins each frame fully wrapped).
- Live against CLI 2.1.261 (`--features integration-tests`): 28 integration tests + 3 subagent wrapping tests (incl. `live_subagent_session_is_fully_wrapped`) pass.
- `python3 scripts/check_claude_schema_drift.py` clean on 2.1.261; snapshot re-baselined (44 labels).
- Workspace clippy (`--all-targets --all-features -D warnings`) clean.

Tested pin (`TESTED_VERSION`, both README lines) and crate version move to 2.1.261.
