### PR TITLE
codex-codes 0.151.5: resnapshot allowWebmcp, Guardian legacy paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.4"
+version = "0.151.5"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.259`, tested against Claude CLI `2.1.259`.
-- **`codex-codes`** — currently `codex-codes 0.151.4`, tested against Codex CLI `0.151.0`.
+- **`codex-codes`** — currently `codex-codes 0.151.5`, tested against Codex CLI `0.151.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
 - **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.15`, tested against google-antigravity `0.1.15` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.151.5] - 2026-09-05
+
+Resnapshots vs `openai/codex@main` (ddf04ad, 2026-09-05).
+
+### Added
+
+- `BrowserUseRequirements.allow_webmcp`, the managed WebMCP policy the app
+  server now exposes (upstream #42823). Omitted when `None`.
+
+### Changed
+
+- `GuardianApprovalReviewAction::Command.cwd`, `::ApplyPatch.cwd`, and
+  `::ApplyPatch.files` are now `LegacyAppPathString` instead of
+  `AbsolutePathBuf`, mirroring upstream's "preserve executor paths in
+  Guardian approval reviews" (#42838). `Execve.cwd` stays `AbsolutePathBuf`.
+
 ## [0.151.4] - 2026-09-04
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.4"
+version = "0.151.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -665,6 +665,14 @@ pub struct AutoReviewRequirements {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowserUseRequirements {
+    /// Managed WebMCP policy: whether the app may use WebMCP-exposed page
+    /// tools. `None` leaves the default in place.
+    #[serde(
+        rename = "allowWebmcp",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_webmcp: Option<bool>,
     #[serde(
         rename = "allowGlobalPersistentApproval",
         default,
@@ -2916,7 +2924,7 @@ pub struct GuardianApprovalReview {
 pub enum GuardianApprovalReviewAction {
     Command {
         command: String,
-        cwd: AbsolutePathBuf,
+        cwd: LegacyAppPathString,
         source: GuardianCommandSource,
     },
     Execve {
@@ -2936,8 +2944,8 @@ pub enum GuardianApprovalReviewAction {
     },
     #[serde(rename = "applyPatch")]
     ApplyPatch {
-        cwd: AbsolutePathBuf,
-        files: Vec<AbsolutePathBuf>,
+        cwd: LegacyAppPathString,
+        files: Vec<LegacyAppPathString>,
     },
     #[serde(rename = "networkAccess")]
     NetworkAccess {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -8098,6 +8098,12 @@
               "null"
             ]
           },
+          "allowWebmcp": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "defaultOriginPolicy": {
             "anyOf": [
               {
@@ -12528,7 +12534,7 @@
                 "type": "string"
               },
               "cwd": {
-                "$ref": "#/definitions/v2/AbsolutePathBuf"
+                "$ref": "#/definitions/v2/LegacyAppPathString"
               },
               "source": {
                 "$ref": "#/definitions/v2/GuardianCommandSource"
@@ -12621,11 +12627,11 @@
           {
             "properties": {
               "cwd": {
-                "$ref": "#/definitions/v2/AbsolutePathBuf"
+                "$ref": "#/definitions/v2/LegacyAppPathString"
               },
               "files": {
                 "items": {
-                  "$ref": "#/definitions/v2/AbsolutePathBuf"
+                  "$ref": "#/definitions/v2/LegacyAppPathString"
                 },
                 "type": "array"
               },

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -1582,6 +1582,12 @@
             "null"
           ]
         },
+        "allowWebmcp": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "defaultOriginPolicy": {
           "anyOf": [
             {
@@ -8539,7 +8545,7 @@
               "type": "string"
             },
             "cwd": {
-              "$ref": "#/definitions/AbsolutePathBuf"
+              "$ref": "#/definitions/LegacyAppPathString"
             },
             "source": {
               "$ref": "#/definitions/GuardianCommandSource"
@@ -8632,11 +8638,11 @@
         {
           "properties": {
             "cwd": {
-              "$ref": "#/definitions/AbsolutePathBuf"
+              "$ref": "#/definitions/LegacyAppPathString"
             },
             "files": {
               "items": {
-                "$ref": "#/definitions/AbsolutePathBuf"
+                "$ref": "#/definitions/LegacyAppPathString"
               },
               "type": "array"
             },


### PR DESCRIPTION
Local run of `scripts/check_codex_schema_drift.py` reported drift against `openai/codex@main` (ddf04ad, 2026-09-05); no nightly issue had been filed yet. Two definitions changed, no new methods or definitions.

## Drift

| Upstream | Crate |
|---|---|
| `BrowserUseRequirements.allowWebmcp` (openai/codex#42823, managed WebMCP policy) | `BrowserUseRequirements.allow_webmcp: Option<bool>` |
| `GuardianApprovalReviewAction` `command` / `applyPatch` variants: `cwd` and `files` moved from `AbsolutePathBuf` to `LegacyAppPathString` (openai/codex#42838, "preserve executor paths in Guardian approval reviews") | `::Command.cwd`, `::ApplyPatch.cwd`, `::ApplyPatch.files` are now `LegacyAppPathString`; `::Execve.cwd` stays `AbsolutePathBuf` as upstream |

Both snapshots refreshed from upstream. Types were hand-edited per the standing recipe (no blind codegen).

## Verification

- `python3 scripts/check_codex_schema_drift.py`: both schema files JSON-identical to upstream.
- `cargo run -p codex-codes --example schema_coverage`: 179/179 modeled defs with sample (100%).
- `cargo test -p codex-codes`: 122 tests pass. Workspace clippy (`--all-targets -D warnings`) clean.

Patch bump to 0.151.5; changelog and top-level README bullet updated.
