### PR TITLE
re-pin codex, muse, opencode, pi to tested CLI releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.151.5"
+version = "0.153.4"
 dependencies = [
  "env_logger",
  "jsonschema",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "env_logger",
  "log",
@@ -1296,7 +1296,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opencode-codes"
-version = "1.18.19"
+version = "1.18.29"
 dependencies = [
  "futures-core",
  "jsonschema",
@@ -1352,7 +1352,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pi-codes"
-version = "0.84.4"
+version = "0.85.1"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.261`, tested against Claude CLI `2.1.261`.
-- **`codex-codes`** — currently `codex-codes 0.151.5`, tested against Codex CLI `0.151.0`.
-- **`opencode-codes`** — currently `opencode-codes 1.18.19` (tested CLI + 1 crate-side patch), tested against opencode `1.18.18`.
-- **`muse-codes`** — currently `muse-codes 1.0.2`, tested against Muse Code `1.0.2` (build `1.0.2-R2040.1`).
+- **`codex-codes`** — currently `codex-codes 0.153.4`, tested against Codex CLI `0.153.4`.
+- **`opencode-codes`** — currently `opencode-codes 1.18.29`, tested against opencode `1.18.29`.
+- **`muse-codes`** — currently `muse-codes 1.0.3`, tested against Muse Code `1.0.3` (build `1.0.3-R2198.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.16`, tested against google-antigravity `0.1.16` (the wheel its bundled harness was generated from).
-- **`pi-codes`** — currently `pi-codes 0.84.4`, tested against pi `0.84.4` (`@earendil-works/pi-coding-agent`; live tier: credential-free RPC surface + model turns and tool conformance when a provider key is present).
+- **`pi-codes`** — currently `pi-codes 0.85.1`, tested against pi `0.85.1` (`@earendil-works/pi-coding-agent`; live tier: credential-free RPC surface + model turns and tool conformance when a provider key is present).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.153.4] - 2026-09-06
+
+### Changed
+
+- Re-baseline the tested pin to Codex CLI **0.153.4**: the full
+  integration suite (27 capture-corpus + 14 live app-server tests,
+  including the strict typed-message audit) and wirecheck's live tier
+  pass unchanged. Crate version follows per the version-means-tested
+  convention; no code changes beyond the pin.
+
 ## [0.151.5] - 2026-09-05
 
 Resnapshots vs `openai/codex@main` (ddf04ad, 2026-09-05).

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.151.5"
+version = "0.153.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.151.0
+**Tested against:** Codex CLI 0.153.4
 
 ## Installation
 
@@ -215,7 +215,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.151.0
+**Tested against:** Codex CLI 0.153.4
 
 The crate version means **tested against**: it names the newest Codex CLI
 the live integration suite has passed against. If you're using a different

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.151.0";
+const TESTED_VERSION: &str = "0.153.4";
 
 /// The Codex CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention.

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-09-06
+
+### Changed
+
+- Re-baseline the tested pin to Muse Code **1.0.3 (1.0.3-R2198.1)**
+  (hosts auto-rolled from 1.0.2): echo fingerprint identical to the
+  snapshot and the full cargo tier (14 unit + 4 corpus + 8 live echo
+  integration) passes unchanged. Pin-only release.
+
 ## [1.0.2] - 2026-09-02
 
 ### Added

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -8,7 +8,7 @@ journal on stdout: envelope records covering command intake, run lifecycle,
 task lifecycle, and streamed output. This crate types that stream and ships
 an async Tokio client for driving headless runs.
 
-Tested against Muse Code 1.0.2 (`1.0.2-R2040.1`). The crate version may
+Tested against Muse Code 1.0.3 (`1.0.3-R2198.1`). The crate version may
 carry a patch offset above the CLI release for crate-side additions.
 
 ## Captured, not guessed

--- a/muse-codes/src/version.rs
+++ b/muse-codes/src/version.rs
@@ -1,14 +1,14 @@
 //! Version pins this crate is tested against.
 
 /// Muse Code release the live suite last passed against
-/// (`muse --version` reports `Muse Code 1.0.2 (1.0.2-R2040.1)`). The
+/// (`muse --version` reports `Muse Code 1.0.3 (1.0.3-R2198.1)`). The
 /// 0.1.0 and 0.2.1 captures remain committed and still parse — 1.0.1's
 /// wire is a near-superset (its one observed break, `profile_id: null`
 /// on `run.model.configured`, is modeled as `Option`).
-pub const TESTED_MUSE_VERSION: &str = "1.0.2";
+pub const TESTED_MUSE_VERSION: &str = "1.0.3";
 
 /// Full build string of the tested binary.
-pub const TESTED_MUSE_BUILD: &str = "1.0.2-R2040.1";
+pub const TESTED_MUSE_BUILD: &str = "1.0.3-R2198.1";
 
 /// Envelope `schema_version` the models target.
 pub const STREAM_SCHEMA_VERSION: u32 = 1;

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.29] - 2026-09-06
+
+### Changed
+
+- Re-baseline the tested pin to opencode **1.18.29** (from 1.18.18):
+  the managed-server live tier (session lifecycle, fork, SSE event
+  stream, hello/bash conformance) passes unchanged; the read/write
+  conformance checks remain provider-gated on this host. Pin-only
+  release.
+
 ## [Unreleased]
 
 ## [1.18.19] - 2026-08-19

--- a/opencode-codes/Cargo.toml
+++ b/opencode-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opencode-codes"
-version = "1.18.19"
+version = "1.18.29"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/opencode-codes/README.md
+++ b/opencode-codes/README.md
@@ -27,7 +27,7 @@ models of the server's OpenAPI 3.1 wire contract, an async (Tokio) client over
 `reqwest`, an SSE reader for the `GET /event` stream, and an optional managed
 launcher for the `opencode serve` process.
 
-**Tested against:** opencode 1.18.18
+**Tested against:** opencode 1.18.29
 
 ## Installation
 

--- a/opencode-codes/src/version.rs
+++ b/opencode-codes/src/version.rs
@@ -4,5 +4,5 @@
 /// also asserted at runtime by the integration tests against the server's
 /// reported version. Kept in lockstep with the README by CI.
 pub fn tested_cli_version() -> &'static str {
-    "1.18.18"
+    "1.18.29"
 }

--- a/pi-codes/CHANGELOG.md
+++ b/pi-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.85.1] - 2026-09-06
+
+### Changed
+
+- Re-baseline the tested pin to pi **0.85.1** (from 0.84.4): the full
+  live tier passes unchanged — six credential-free RPC checks, a
+  streamed model turn, the model-tool conformance trio (disk-verified),
+  and the 5 corpus tests over the committed 0.84.4 tool-use capture,
+  which still parses fully typed. Pin-only release.
+
 ## [0.84.4] - 2026-09-02
 
 ### Changed

--- a/pi-codes/Cargo.toml
+++ b/pi-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-codes"
-version = "0.84.4"
+version = "0.85.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/pi-codes/README.md
+++ b/pi-codes/README.md
@@ -5,7 +5,7 @@ Typed Rust SDK for the [pi coding agent](https://github.com/earendil-works/pi)
 `pi --mode json` JSONL event stream and the `pi --mode rpc` stdin/stdout
 command protocol, plus an async (Tokio) RPC client.
 
-Tested against pi 0.84.4. The crate version may carry a patch offset
+Tested against pi 0.85.1. The crate version may carry a patch offset
 above the CLI release for crate-side additions.
 
 ## What's covered

--- a/pi-codes/src/version.rs
+++ b/pi-codes/src/version.rs
@@ -6,7 +6,7 @@
 /// credential-free RPC surface (state, models, bash, session commands)
 /// and the full deserialization suite; model-turn coverage requires a
 /// configured provider and is gated the same way.
-pub const TESTED_PI_VERSION: &str = "0.84.4";
+pub const TESTED_PI_VERSION: &str = "0.85.1";
 
 /// The pi release this crate's live suite last passed against — the
 /// machine-readable form of the crate's version convention. Kept in


### PR DESCRIPTION
All four bumps from yesterday's harness-update sweep, approved by Matt. Every binary was updated and its full integration tier re-run green before the pin moved (claude was already current at 2.1.261 and needs nothing):

| crate | version | tested pin | evidence |
|---|---|---|---|
| codex-codes | 0.151.5 → **0.153.4** | 0.151.0 → 0.153.4 | 49/49 cargo tier incl. strict typed audit; 9/9 wirecheck live |
| muse-codes | 1.0.2 → **1.0.3** | 1.0.2 → 1.0.3 (`1.0.3-R2198.1`) | echo fingerprint identical; 26/26 cargo tier |
| opencode-codes | 1.18.19 → **1.18.29** | 1.18.18 → 1.18.29 | managed-server live tier green (read/write conformance stays provider-gated, as with the current pin) |
| pi-codes | 0.84.4 → **0.85.1** | 0.84.4 → 0.85.1 | 27/27 incl. live model turns + disk-verified tool conformance; 0.84.4 corpus still parses typed |

Pin-only changes: version.rs consts, both README tiers, Cargo.tomls, and four CHANGELOG entries — no code. CI lockstep clauses cover all four.

**On merge this publishes four crates in one workflow run — including pi-codes, which is the live test of the new all-crates `CARGO_REGISTRY_TOKEN`** (the old token 403'd on pi-codes twice). If pi-codes still fails, I'll publish it locally and flag the token again.