### PR TITLE
claude-codes 2.1.263: re-pin to tested Claude CLI release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.261"
+version = "2.1.263"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.261`, tested against Claude CLI `2.1.261`.
+- **`claude-codes`** — currently `claude-codes 2.1.263`, tested against Claude CLI `2.1.263`.
 - **`codex-codes`** — currently `codex-codes 0.153.4`, tested against Codex CLI `0.153.4`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.29`, tested against opencode `1.18.29`.
 - **`muse-codes`** — currently `muse-codes 1.0.3`, tested against Muse Code `1.0.3` (build `1.0.3-R2198.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.263] - 2026-09-07
+
+### Changed
+
+- Re-baseline the tested pin to Claude CLI **2.1.263**: `TESTED_VERSION`,
+  both README `Tested against:` lines and the crate version move to 2.1.263.
+  A full field-by-field diff of the extracted stream-json schemas
+  (2.1.261 → 2.1.263) shows only renamed minified identifiers; every wire
+  label, field and enum is unchanged, and the committed snapshot is
+  byte-identical after `--update`. The integration suite passes unchanged
+  against 2.1.263. No code changes beyond the pin.
+
 ## [2.1.261] - 2026-09-05
 
 Re-baseline against Claude CLI **2.1.261**: the tested pin (`TESTED_VERSION`,

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.261"
+version = "2.1.263"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.261
+**Tested against:** Claude CLI 2.1.263
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.261**
+//! Current tested version: **2.1.263**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.261";
+const TESTED_VERSION: &str = "2.1.263";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention


### PR DESCRIPTION
## Summary

- Re-pin \`claude-codes\` to Claude CLI **2.1.263** (crate version, \`TESTED_VERSION\`, both README \`Tested against:\` lines, changelog).
- No schema changes: the nightly-style fingerprint check is clean on 2.1.263, \`--update\` leaves the committed snapshot byte-identical, and a normalized field-by-field diff of the full extracted schemas (2.1.261 → 2.1.263) shows only renamed minified identifiers (e.g. the zod enum helper \`X\` → \`K\`; the \`/context\` category-row schema moved chunks but is unchanged).
- No open drift issues existed; the sweep also confirmed codex, muse, opencode, pi and antigravity are all at their latest upstream release with clean drift checks.

## Test plan

- [x] \`cargo test -p claude-codes\` (282 passed)
- [x] \`cargo test -p claude-codes --features integration-tests --test integration_tests\` against CLI 2.1.263 (28 passed)
- [x] \`cargo fmt --all\` / \`cargo clippy -p claude-codes --all-targets --all-features -- -D warnings\`