### PR TITLE
claude-codes 2.1.266: model 2.1.263 to 2.1.266 stream-json drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.263"
+version = "2.1.266"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.263`, tested against Claude CLI `2.1.263`.
+- **`claude-codes`** — currently `claude-codes 2.1.266`, tested against Claude CLI `2.1.266`.
 - **`codex-codes`** — currently `codex-codes 0.153.4`, tested against Codex CLI `0.153.4`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.29`, tested against opencode `1.18.29`.
 - **`muse-codes`** — currently `muse-codes 1.0.3`, tested against Muse Code `1.0.3` (build `1.0.3-R2198.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.266] - 2026-09-09
+
+Re-baseline against Claude CLI **2.1.266**. Models the 2.1.263 → 2.1.266
+stream-json drift, all additive (no removals or required/optional flips).
+
+### Added
+
+- `SystemSubtype::DevIntent` / `DevIntentMessage` / `DevIntentKind` /
+  `KnownSystemEvent::DevIntent`, plus `SystemMessage::is_dev_intent` /
+  `as_dev_intent` — the new `system/dev_intent` frame the CLI emits once per
+  recognized kind of development work per conversation (e.g. `ios_app`, which
+  Claude Code Desktop keys its iOS Simulator entry point on). `kind` is an
+  open enum with an `Unknown` fallback, matching the CLI's "ignore a kind you
+  do not recognize" contract.
+- `AssistantMessage.historical` and `AssistantMessage.wire_ingest_context` —
+  the Remote Control replay flag and the input-normalization provenance map
+  that rides alongside `wire_tool_inputs`.
+- `ResultMessage.runner_exit` (`RunnerExit` with an open `RunnerExitPhase`
+  enum) — set by the self-hosted runner on a synthesized failure result when
+  the session process fails to start or exits abnormally.
+- `InitMessage.startup_timing` — cold-start telemetry (named phases and
+  resume-hydration counters) on hosted-session init frames, stored as raw
+  JSON.
+- `CompactBoundaryMessage.historical` and `UserMessage.historical` — the same
+  Remote Control replay flag on those two frames.
+
+### Changed
+
+- The committed schema snapshot moves to 2.1.266. Between 2.1.263 and 2.1.266
+  the CLI also tightened the assistant/user `message` field from `z.unknown()`
+  to a concrete Anthropic-Messages-API schema, so the extractor now reaches
+  the API content-block schemas (`text`, `image`, `thinking`, `tool_use`,
+  `tool_result`, `document`, `search_result`, `redacted_thinking`,
+  `tool_reference`, `file`, `url`, `message`) and the snapshot records them.
+  These are passthrough shapes the crate already types via `ContentBlock`
+  (with an `Unknown` fallback), so no new content-block modeling is required;
+  the wire JSON is unchanged. The full live integration suite passes against
+  2.1.266.
+
 ## [2.1.263] - 2026-09-07
 
 ### Changed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.263"
+version = "2.1.266"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.263
+**Tested against:** Claude CLI 2.1.266
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -75,6 +75,7 @@ impl ClaudeInput {
             file_attachments: None,
             seeded_summon: None,
             client_composed: None,
+            historical: None,
         })
     }
 
@@ -112,6 +113,7 @@ impl ClaudeInput {
             file_attachments: None,
             seeded_summon: None,
             client_composed: None,
+            historical: None,
         })
     }
 

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -45,6 +45,7 @@ pub enum SystemSubtype {
     VcsStateChanged,
     FeedbackDraftQueued,
     CloudSessionDelta,
+    DevIntent,
     /// A subtype not yet known to this version of the crate.
     Unknown(String),
 }
@@ -84,6 +85,7 @@ impl SystemSubtype {
             Self::VcsStateChanged => "vcs_state_changed",
             Self::FeedbackDraftQueued => "feedback_draft_queued",
             Self::CloudSessionDelta => "cloud_session_delta",
+            Self::DevIntent => "dev_intent",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -130,6 +132,7 @@ impl From<&str> for SystemSubtype {
             "vcs_state_changed" => Self::VcsStateChanged,
             "feedback_draft_queued" => Self::FeedbackDraftQueued,
             "cloud_session_delta" => Self::CloudSessionDelta,
+            "dev_intent" => Self::DevIntent,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -697,6 +700,11 @@ pub struct UserMessage {
     /// type; its text is delivered as written (CLI 2.1.259+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_composed: Option<bool>,
+    /// Replayed history rather than a live message: the Remote Control
+    /// bridge stamps it on the messages it flushes to the session server,
+    /// which also stamps it on deliveries it replays (CLI 2.1.266+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub historical: Option<bool>,
 }
 
 impl UserMessage {
@@ -1060,6 +1068,19 @@ impl SystemMessage {
         serde_json::from_value(self.data.clone()).ok()
     }
 
+    /// Check if this is a dev_intent message.
+    pub fn is_dev_intent(&self) -> bool {
+        self.subtype == SystemSubtype::DevIntent
+    }
+
+    /// Try to parse as a dev_intent message.
+    pub fn as_dev_intent(&self) -> Option<DevIntentMessage> {
+        if self.subtype != SystemSubtype::DevIntent {
+            return None;
+        }
+        serde_json::from_value(self.data.clone()).ok()
+    }
+
     /// Parse any typed system subtype known to this crate version.
     pub fn as_known_system_event(&self) -> Option<KnownSystemEvent> {
         macro_rules! parse {
@@ -1125,6 +1146,7 @@ impl SystemMessage {
             SystemSubtype::CloudSessionDelta => {
                 parse!(CloudSessionDelta, CloudSessionDeltaMessage)
             }
+            SystemSubtype::DevIntent => parse!(DevIntent, DevIntentMessage),
             SystemSubtype::Unknown(_) => None,
         }
     }
@@ -1204,6 +1226,7 @@ impl SystemMessage {
             SystemSubtype::CloudSessionDelta => {
                 reserialize(parse_system::<CloudSessionDeltaMessage>(self))
             }
+            SystemSubtype::DevIntent => reserialize(parse_system::<DevIntentMessage>(self)),
             SystemSubtype::Unknown(_) => None,
         }
     }
@@ -1253,6 +1276,7 @@ pub enum KnownSystemEvent {
     VcsStateChanged(VcsStateChangedMessage),
     FeedbackDraftQueued(FeedbackDraftQueuedMessage),
     CloudSessionDelta(CloudSessionDeltaMessage),
+    DevIntent(DevIntentMessage),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1824,6 +1848,12 @@ pub struct InitMessage {
     /// none was found. Absent on other platforms and on CLIs before 2.1.259.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub powershell_path: Option<Option<String>>,
+
+    /// Cold-start telemetry for hosted (CCR) sessions: named startup phases
+    /// and resume-hydration counters. Absent elsewhere. Stored as raw JSON
+    /// (the shape is internal and evolving) (CLI 2.1.266+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timing: Option<serde_json::Map<String, Value>>,
 }
 
 /// The server-configured session indicator that the terminal renders as a
@@ -1890,6 +1920,11 @@ pub struct CompactBoundaryMessage {
     /// Logical parent across the compaction boundary.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logical_parent_uuid: Option<Option<String>>,
+    /// Replayed history rather than a live message, stamped by the Remote
+    /// Control bridge when it flushes history to the session server
+    /// (CLI 2.1.266+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub historical: Option<bool>,
 }
 
 /// Metadata about context compaction
@@ -2439,6 +2474,75 @@ pub struct CloudSessionDeltaMessage {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// `system/dev_intent` — the conversation shows a known kind of development
+/// work, for hosts that key tooling on it (Claude Code Desktop opens its iOS
+/// Simulator entry point on `ios_app`). Sent with no other payload at most
+/// once per kind per conversation per process: when the evidence for that
+/// kind first completes, or at startup when a resumed conversation already
+/// has it (possibly before `system/init`). A rewind or compaction never
+/// retracts it and only a `conversation_reset` starts over, so treat each
+/// kind as a sticky fact about the conversation and ignore repeats
+/// (CLI 2.1.266+).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DevIntentMessage {
+    /// What kind of development the conversation turned out to be doing.
+    pub kind: DevIntentKind,
+    pub uuid: String,
+    pub session_id: String,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// The kind of development a [`DevIntentMessage`] reports. Open set: the CLI
+/// says "more kinds will be added; ignore a kind you do not recognize", so
+/// unrecognized values deserialize to [`DevIntentKind::Unknown`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DevIntentKind {
+    /// Claude wrote or edited a `.swift` file and something it wrote, read, or
+    /// ran is iPhone-specific (a macOS-only app or server-side Swift package
+    /// never qualifies).
+    IosApp,
+    /// A kind not yet known to this version of the crate.
+    Unknown(String),
+}
+
+impl DevIntentKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::IosApp => "ios_app",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for DevIntentKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for DevIntentKind {
+    fn from(s: &str) -> Self {
+        match s {
+            "ios_app" => Self::IosApp,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for DevIntentKind {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for DevIntentKind {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
+}
+
 /// `{id, name}` of an original `Batch*` tool_use block, carried in
 /// [`AssistantMessage::batch_tool_uses`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -2621,6 +2725,18 @@ pub struct AssistantMessage {
     /// Wrapper-level sibling — never inside `message.content` (CLI 2.1.259+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wire_tool_inputs: Option<serde_json::Map<String, Value>>,
+    /// What the client-side input normalization read from process state for
+    /// the inputs in [`wire_tool_inputs`](Self::wire_tool_inputs), keyed by
+    /// the same `tool_use` ids. Round-tripped so a replayed history can verify
+    /// each recorded input against the normalized one. Wrapper-level sibling —
+    /// never inside `message.content` (CLI 2.1.266+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wire_ingest_context: Option<serde_json::Map<String, Value>>,
+    /// Replayed history rather than a live message, stamped by the Remote
+    /// Control bridge when it flushes history to the session server, which
+    /// also stamps it on deliveries it replays (CLI 2.1.266+).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub historical: Option<bool>,
     /// The originating `system/local_command` row's wire-form content,
     /// carried on the loop-synthesized local-command twin so a bridge/SDK
     /// history replay rebuilds the internal system row instead of dropping

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -149,6 +149,81 @@ pub struct ResultMessage {
     /// Provenance of the message/run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<super::message_types::MessageOrigin>,
+
+    /// Set by the self-hosted runner on the result it synthesizes when the
+    /// session process fails to start or exits abnormally. Absent on normal
+    /// results and on CLIs before 2.1.266.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_exit: Option<RunnerExit>,
+}
+
+/// How the self-hosted runner's session process terminated, carried on a
+/// synthesized failure [`ResultMessage`] as [`ResultMessage::runner_exit`]
+/// (CLI 2.1.266+).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RunnerExit {
+    /// Which phase the process was in when it exited.
+    pub phase: RunnerExitPhase,
+    /// Process exit code. Absent (or wire `null`) when it exited on a signal
+    /// instead, or when the runner did not capture one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
+    /// Terminating signal name. Absent (or wire `null`) when it exited with a
+    /// code instead, or when the runner did not capture one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+}
+
+/// Which phase the runner's session process was in when it exited, in
+/// [`RunnerExit::phase`]. Open set — unrecognized values deserialize to
+/// [`RunnerExitPhase::Unknown`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RunnerExitPhase {
+    /// Failed while starting up.
+    Setup,
+    /// Failed once running.
+    Run,
+    /// A phase not yet known to this version of the crate.
+    Unknown(String),
+}
+
+impl RunnerExitPhase {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Setup => "setup",
+            Self::Run => "run",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for RunnerExitPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for RunnerExitPhase {
+    fn from(s: &str) -> Self {
+        match s {
+            "setup" => Self::Setup,
+            "run" => Self::Run,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for RunnerExitPhase {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RunnerExitPhase {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 /// Usage and cost for a single model within a session, as found in

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.263**
+//! Current tested version: **2.1.266**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!
@@ -168,9 +168,9 @@ pub use io::{
     CodeChangePublishedMessage, CommandInfo, CommandsChangedMessage, CompactBoundaryMessage,
     CompactMetadata, CompactionTrigger, ContextAgent, ContextCategory, ContextMcpTool,
     ContextMemoryFile, ContextOverLimit, ContextSkill, ContextUsage, ControlRequestProgressMessage,
-    ElicitationCompleteMessage, FailedPersistedFile, FeedbackDraftQueuedMessage,
-    FilesPersistedMessage, HookProgressMessage, HookResponseMessage, HookStartedMessage,
-    InformationalMessage, InitMessage, InitPermissionMode, KnownSystemEvent,
+    DevIntentKind, DevIntentMessage, ElicitationCompleteMessage, FailedPersistedFile,
+    FeedbackDraftQueuedMessage, FilesPersistedMessage, HookProgressMessage, HookResponseMessage,
+    HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode, KnownSystemEvent,
     LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths, MemoryRecallItem,
     MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey, MirrorErrorMessage,
     ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage, NotificationMessage, OutputStyle,
@@ -200,9 +200,9 @@ pub use io::{
 
 // Usage types
 pub use io::{
-    AssistantUsage, CacheCreationDetails, DeferredToolUse, FastModeDisabledReason, ServerToolUse,
-    SubagentKillCounts, SubagentRefusalCounts, SubagentResult, SubagentSpawnRequests,
-    SubagentStats, SubagentToolStats, SubagentUsageRollup, UsageInfo,
+    AssistantUsage, CacheCreationDetails, DeferredToolUse, FastModeDisabledReason, RunnerExit,
+    RunnerExitPhase, ServerToolUse, SubagentKillCounts, SubagentRefusalCounts, SubagentResult,
+    SubagentSpawnRequests, SubagentStats, SubagentToolStats, SubagentUsageRollup, UsageInfo,
 };
 
 // Typed tool input types

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.263";
+const TESTED_VERSION: &str = "2.1.266";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schema_2_1_266_tests.rs
+++ b/claude-codes/tests/schema_2_1_266_tests.rs
@@ -1,0 +1,244 @@
+//! Coverage for the CLI 2.1.266 stream-json additive drift.
+//!
+//! 2.1.263 → 2.1.266 added one `system` subtype (`dev_intent`) and top-level
+//! fields to four wire types, all additive (no removals). Between the two
+//! releases the CLI also tightened the assistant/user `message` field from
+//! `z.unknown()` to a concrete Anthropic-API-shaped schema; that is a
+//! passthrough shape the crate already types via [`ContentBlock`], so it needs
+//! no new modeling and is not exercised here.
+//!
+//! Each frame below carries the new fields and is asserted **fully wrapped** —
+//! the typed model captures every wire field with nothing left in an untyped
+//! escape hatch.
+
+use claude_codes::{
+    assert_fully_wrapped, ClaudeOutput, DevIntentKind, KnownSystemEvent, RunnerExitPhase,
+    SystemSubtype,
+};
+use serde_json::json;
+
+/// The new `system/dev_intent` subtype is modeled, round-trips fully wrapped,
+/// and exposes its `kind` through the typed accessors.
+#[test]
+fn system_dev_intent_fully_wrapped() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "dev_intent",
+        "kind": "ios_app",
+        "uuid": "u1",
+        "session_id": "s1",
+        "future_field": "preserved"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected System");
+    };
+    assert_eq!(sys.subtype, SystemSubtype::DevIntent);
+    assert!(sys.is_dev_intent());
+
+    let direct = sys.as_dev_intent().expect("direct typed accessor");
+    assert_eq!(direct.kind, DevIntentKind::IosApp);
+    assert_eq!(direct.uuid, "u1");
+    assert_eq!(direct.session_id, "s1");
+    assert_eq!(direct.extra["future_field"], "preserved");
+
+    let Some(KnownSystemEvent::DevIntent(known)) = sys.as_known_system_event() else {
+        panic!("expected DevIntent event");
+    };
+    assert_eq!(known.kind.as_str(), "ios_app");
+}
+
+/// An unrecognized `dev_intent` kind falls back to `Unknown` rather than
+/// failing the frame — the CLI documents the set as open.
+#[test]
+fn system_dev_intent_unknown_kind() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "dev_intent",
+        "kind": "android_app",
+        "uuid": "u1",
+        "session_id": "s1"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected System");
+    };
+    let direct = sys.as_dev_intent().unwrap();
+    assert_eq!(
+        direct.kind,
+        DevIntentKind::Unknown("android_app".to_string())
+    );
+    assert_eq!(direct.kind.as_str(), "android_app");
+}
+
+/// An `assistant` frame carrying the 2.1.266 `historical` and
+/// `wire_ingest_context` wrapper siblings round-trips without loss.
+#[test]
+fn assistant_carries_historical_and_wire_ingest_context() {
+    let frame = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "done"}],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1",
+        "uuid": "u1",
+        "parent_tool_use_id": null,
+        "historical": true,
+        "wire_ingest_context": {"toolu_1": {"cwd": "/repo"}}
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.historical, Some(true));
+    assert_eq!(msg.wire_ingest_context.unwrap()["toolu_1"]["cwd"], "/repo");
+
+    // Older frames without the fields default to absent and do not serialize
+    // the keys back.
+    let old = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1"
+    });
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(old).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.historical, None);
+    assert!(msg.wire_ingest_context.is_none());
+    let reserialized = serde_json::to_string(&msg).unwrap();
+    assert!(!reserialized.contains("historical"));
+    assert!(!reserialized.contains("wire_ingest_context"));
+}
+
+/// A `result` frame carrying the 2.1.266 `runner_exit` failure payload
+/// round-trips, including a `null` exit code that rode a terminating signal.
+#[test]
+fn result_carries_runner_exit() {
+    let frame = json!({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": true,
+        "duration_ms": 5,
+        "duration_api_ms": 0,
+        "num_turns": 0,
+        "session_id": "s1",
+        "total_cost_usd": 0.0,
+        "runner_exit": {"phase": "setup", "exit_code": null, "signal": "SIGKILL"}
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Result(res) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected result");
+    };
+    let runner_exit = res.runner_exit.expect("runner_exit present");
+    assert_eq!(runner_exit.phase, RunnerExitPhase::Setup);
+    assert_eq!(runner_exit.exit_code, None);
+    assert_eq!(runner_exit.signal, Some("SIGKILL".to_string()));
+
+    // The `run`-phase variant with a numeric exit code also round-trips.
+    let run_frame = json!({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": true,
+        "duration_ms": 5,
+        "duration_api_ms": 0,
+        "num_turns": 0,
+        "session_id": "s1",
+        "total_cost_usd": 0.0,
+        "runner_exit": {"phase": "run", "exit_code": 137}
+    });
+    assert_fully_wrapped(&run_frame);
+    let ClaudeOutput::Result(res) = serde_json::from_value(run_frame).unwrap() else {
+        panic!("expected result");
+    };
+    let runner_exit = res.runner_exit.unwrap();
+    assert_eq!(runner_exit.phase, RunnerExitPhase::Run);
+    assert_eq!(runner_exit.exit_code, Some(137));
+    assert_eq!(runner_exit.signal, None);
+}
+
+/// A `system/init` frame carrying the 2.1.266 `startup_timing` map round-trips
+/// fully wrapped.
+#[test]
+fn system_init_carries_startup_timing() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": "s1",
+        "uuid": "u1",
+        "startup_timing": {"phase_boot_ms": 42, "resume_hydrated_messages": 3}
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected System");
+    };
+    let init = sys.as_init().expect("typed init");
+    assert_eq!(init.startup_timing.unwrap()["phase_boot_ms"], 42);
+}
+
+/// A `system/compact_boundary` frame carrying the 2.1.266 `historical` flag
+/// round-trips fully wrapped.
+#[test]
+fn system_compact_boundary_carries_historical() {
+    let frame = json!({
+        "type": "system",
+        "subtype": "compact_boundary",
+        "session_id": "s1",
+        "uuid": "u1",
+        "compact_metadata": {"trigger": "auto", "pre_tokens": 1000},
+        "historical": true
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::System(sys) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected System");
+    };
+    let cb = sys.as_compact_boundary().expect("typed compact_boundary");
+    assert_eq!(cb.historical, Some(true));
+}
+
+/// A `user` frame carrying the 2.1.266 `historical` flag round-trips fully
+/// wrapped.
+#[test]
+fn user_carries_historical() {
+    let frame = json!({
+        "type": "user",
+        "message": {"role": "user", "content": []},
+        "session_id": "11111111-1111-1111-1111-111111111111",
+        "historical": true
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::User(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected user");
+    };
+    assert_eq!(msg.historical, Some(true));
+}

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -3,24 +3,32 @@
 # One line per wire label: `<type[/subtype]>: comma-separated top-level field keys`.
 # Minified schema names and nested/describe() detail are intentionally omitted;
 # see the header of check_claude_schema_drift.py for the comparison contract.
-# union_members: 44
+# union_members: 45
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, is_api_error_message, is_meta, is_virtual, local_command_source, message, narration_block_indexes, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_tool_inputs
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, historical, is_api_error_message, is_meta, is_virtual, local_command_source, message, narration_block_indexes, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_ingest_context, wire_tool_inputs
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
+content: content, type
 conversation_reset: new_conversation_id, session_id, type, uuid
+document: cache_control, citations, context, source, title, type
+file: file_id, type
+image: cache_control, source, type
+message: container, content, context_management, id, model, role, stop_details, stop_reason, stop_sequence, type, usage
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
-result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
+redacted_thinking: data, type
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, runner_exit, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
 result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, first_content_frame_ms, first_stream_post_ack_ms, first_stream_post_ms, first_stream_post_wall_ms, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
+search_result: cache_control, citations, content, source, title, type
 stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, user_message_uuid, user_message_uuids, uuid
 system/api_retry: attempt, error, error_status, max_retries, no_response, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
 system/cloud_session_delta: changed, cloud_session, seq, session_id, subtype, type, uuid
 system/code_change_published: action, branch, identifier, provider, repo, session_id, subtype, type, url, uuid
 system/commands_changed: commands, session_id, subtype, type, uuid
-system/compact_boundary: compact_metadata, logical_parent_uuid, session_id, subtype, type, uuid
+system/compact_boundary: compact_metadata, historical, logical_parent_uuid, session_id, subtype, type, uuid
 system/control_request_progress: attempt, error_status, max_retries, request_id, retry_delay_ms, session_id, status, subtype, type, uuid
+system/dev_intent: kind, session_id, subtype, type, uuid
 system/elicitation_complete: elicitation_id, mcp_server_name, session_id, subtype, type, uuid
 system/feedback_draft_queued: details_preview, draft_id, draft_type, session_id, subtype, title, type, uuid
 system/files_persisted: failed, files, processed_at, session_id, subtype, type, uuid
@@ -28,7 +36,7 @@ system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr
 system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
 system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
-system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, footer_indicator, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, powershell_path, product_feedback_disabled, session_id, skills, slash_commands, subtype, terminal_slash_commands, tools, type, uuid, worker_epoch
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cloud_session, cwd, effort, fast_mode_disabled_reason, fast_mode_state, footer_indicator, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, powershell_path, product_feedback_disabled, session_id, skills, slash_commands, startup_timing, subtype, terminal_slash_commands, tools, type, uuid, worker_epoch
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid
@@ -46,6 +54,12 @@ system/task_updated: patch, session_id, subtype, task_id, type, uuid
 system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, user_message_uuid, uuid
 system/vcs_state_changed: branch, cwd, kind, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid
+text: citations, text, type
+thinking: signature, thinking, type
 tool_progress: elapsed_time_seconds, heartbeat, parent_tool_use_id, session_id, subagent_retry, subagent_type, task_id, tool_name, tool_use_id, type, uuid
+tool_reference: tool_name, type
+tool_result: cache_control, content, is_error, tool_use_id, type
+tool_use: caller, id, input, name, type
 tool_use_summary: preceding_tool_use_ids, session_id, summary, timestamp, type, uuid
-user: client_composed, client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type
+url: type, url
+user: client_composed, client_platform, historical, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, seeded_summon, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_result_meta, tool_use_result, type


### PR DESCRIPTION
## Summary

The nightly Claude schema-drift check is clean against the *installed* CLI, but Claude Code **2.1.266** shipped after it and carries real, additive stream-json drift. This re-pins the crate and models it. All changes are additive — no wire labels or fields were removed and no required/optional flips.

### New subtype

- `system/dev_intent` — `SystemSubtype::DevIntent`, `DevIntentMessage`, `DevIntentKind` (open enum with `Unknown` fallback per the CLI's "ignore a kind you do not recognize" contract), `KnownSystemEvent::DevIntent`, and `is_dev_intent` / `as_dev_intent` accessors. The CLI emits this once per recognized kind of development work per conversation (e.g. `ios_app`, which Claude Code Desktop keys its iOS Simulator entry point on).

### New fields

- `AssistantMessage.historical`, `AssistantMessage.wire_ingest_context`
- `ResultMessage.runner_exit` (`RunnerExit` + open `RunnerExitPhase` enum) — synthesized by the self-hosted runner when the session process fails to start or exits abnormally
- `InitMessage.startup_timing` — hosted-session cold-start telemetry, raw JSON
- `CompactBoundaryMessage.historical`, `UserMessage.historical`

### Message field tightened upstream (passthrough, no crate change)

Between 2.1.263 and 2.1.266 the CLI tightened the assistant/user `message` field from `z.unknown()` to a concrete Anthropic-Messages-API schema. The extractor therefore now reaches the API content-block schemas (`text`, `image`, `thinking`, `tool_use`, `tool_result`, `document`, `search_result`, `redacted_thinking`, `tool_reference`, `file`, `url`, `message`), and the committed snapshot records them. These are passthrough shapes the crate already types via `ContentBlock` (with an `Unknown` fallback); the wire JSON is unchanged, so no new content-block modeling is needed.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy -p claude-codes --all-targets --all-features -- -D warnings`
- [x] `cargo test -p claude-codes` — new `tests/schema_2_1_266_tests.rs` asserts every new frame is fully wrapped (7 tests)
- [x] `scripts/check_claude_schema_drift.py --binary <2.1.266>` reports no drift against the refreshed snapshot

## Pins

Crate version, `TESTED_VERSION`, `lib.rs` doc, and both README `Tested against:` lines move to 2.1.266.