### PR TITLE
codex-codes 0.153.5: resnapshot FeedbackUploadResponse.promptHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.153.4"
+version = "0.153.5"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.266`, tested against Claude CLI `2.1.266`.
-- **`codex-codes`** — currently `codex-codes 0.153.4`, tested against Codex CLI `0.153.4`.
+- **`codex-codes`** — currently `codex-codes 0.153.5`, tested against Codex CLI `0.153.4`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.30`, tested against opencode `1.18.30`.
 - **`muse-codes`** — currently `muse-codes 1.0.3`, tested against Muse Code `1.0.3` (build `1.0.3-R2198.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.16`, tested against google-antigravity `0.1.16` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.153.5] - 2026-09-10
+
+Resnapshots vs `openai/codex@main` (b348fc2, 2026-09-10).
+
+### Added
+
+- `FeedbackUploadResponse.prompt_hash`, the whitespace-normalized SHA-256 of
+  the session base instructions that `feedback/upload` now returns alongside
+  the thread id (upstream #44325). `None` when the reported rollout has no
+  prompt metadata; omitted from the wire when `None`.
 
 ### Fixed
 
@@ -13,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `next_message()` or cancelling `request()` during a partial inbound frame now
   preserves the partial JSON line for the next read, without losing or
   duplicating frames.
+
 ## [0.153.4] - 2026-09-06
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.153.4"
+version = "0.153.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -2264,6 +2264,15 @@ pub struct FeedbackUploadParams {
 pub struct FeedbackUploadResponse {
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+    /// Whitespace-normalized SHA-256 of the session base instructions, matching
+    /// the uploaded `prompt_hash` tag. Does not include later developer
+    /// messages. `None` when the reported rollout has no prompt metadata.
+    #[serde(
+        rename = "promptHash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub prompt_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -2,8 +2,8 @@ use codex_codes::io::items::{
     CommandExecutionStatus, FileChangeItem, PatchApplyStatus, PatchChangeKind, ThreadItem,
 };
 use codex_codes::protocol::{
-    ConfigReadResponse, GetAccountRateLimitsParams, GetAccountRateLimitsResponse, McpServerStatus,
-    Thread, ThreadListParams,
+    ConfigReadResponse, FeedbackUploadResponse, GetAccountRateLimitsParams,
+    GetAccountRateLimitsResponse, McpServerStatus, Thread, ThreadListParams,
 };
 use codex_codes::{
     JsonRpcMessage, JsonRpcNotification, McpServerElicitationRequestParams, Notification,
@@ -179,6 +179,28 @@ fn mcp_server_status_decodes_tools_error() {
     assert!(serde_json::to_value(healthy)
         .unwrap()
         .get("toolsError")
+        .is_none());
+}
+
+/// FeedbackUploadResponse.promptHash decodes the base-instructions hash and is omitted when the rollout has no prompt metadata.
+#[test]
+fn feedback_upload_response_decodes_prompt_hash() {
+    let response: FeedbackUploadResponse = serde_json::from_value(serde_json::json!({
+        "threadId": "thr_123",
+        "promptHash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    }))
+    .unwrap();
+    assert_eq!(
+        response.prompt_hash.as_deref(),
+        Some("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+    );
+
+    let bare: FeedbackUploadResponse =
+        serde_json::from_value(serde_json::json!({"threadId": "thr_123"})).unwrap();
+    assert_eq!(bare.prompt_hash, None);
+    assert!(serde_json::to_value(bare)
+        .unwrap()
+        .get("promptHash")
         .is_none());
 }
 

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -11502,6 +11502,14 @@
       "FeedbackUploadResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "promptHash": {
+            "default": null,
+            "description": "Whitespace-normalized SHA-256 of the session base instructions, matching the uploaded `prompt_hash` tag. Does not include later developer messages. Null when the reported rollout has no prompt metadata.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "threadId": {
             "type": "string"
           }

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -7402,6 +7402,14 @@
     "FeedbackUploadResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "promptHash": {
+          "default": null,
+          "description": "Whitespace-normalized SHA-256 of the session base instructions, matching the uploaded `prompt_hash` tag. Does not include later developer messages. Null when the reported rollout has no prompt metadata.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "threadId": {
           "type": "string"
         }


### PR DESCRIPTION
## Summary

Nightly drift check for `codex-codes` flagged one changed definition against `openai/codex@main` (b348fc2, 2026-09-10): `FeedbackUploadResponse` gained an optional `promptHash` (upstream openai/codex#44325). No definitions were added or removed; the other four crates (claude, opencode, muse, antigravity) checked clean.

- Refresh both app-server schema snapshots (JSON-identical to upstream)
- Add `FeedbackUploadResponse.prompt_hash: Option<String>`, `#[serde(default, skip_serializing_if)]`, mirroring upstream's `feedback.rs`
- Round-trip integration test for present and absent `promptHash`
- Bump `codex-codes` to 0.153.5; changelog entry also picks up the pending cancellation-safe framing fix from `Unreleased`
- Tested pin stays at Codex CLI 0.153.4 (0.154.0 shipped 2026-09-09 and is a separate re-pin)

## Verification

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p codex-codes`: all pass (28 integration tests incl. the new one)
- `cargo run -p codex-codes --example schema_coverage`: exit 0, 100% with-sample
- `scripts/check_codex_schema_drift.py`: both snapshots JSON-identical to upstream
- `scripts/check_test_annotations.py --check`: all 180 annotated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
