### PR TITLE
Re-pin claude, codex, muse to latest tested CLI releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.266"
+version = "2.1.267"
 dependencies = [
  "anyhow",
  "base64",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.153.5"
+version = "0.154.0"
 dependencies = [
  "env_logger",
  "jsonschema",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "1.0.3"
+version = "1.1.1"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.266`, tested against Claude CLI `2.1.266`.
-- **`codex-codes`** — currently `codex-codes 0.153.5`, tested against Codex CLI `0.153.4`.
+- **`claude-codes`** — currently `claude-codes 2.1.267`, tested against Claude CLI `2.1.267`.
+- **`codex-codes`** — currently `codex-codes 0.154.0`, tested against Codex CLI `0.154.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.30`, tested against opencode `1.18.30`.
-- **`muse-codes`** — currently `muse-codes 1.0.3`, tested against Muse Code `1.0.3` (build `1.0.3-R2198.1`).
+- **`muse-codes`** — currently `muse-codes 1.1.1`, tested against Muse Code `1.1.1` (build `1.1.1-R2514.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.16`, tested against google-antigravity `0.1.16` (the wheel its bundled harness was generated from).
 - **`pi-codes`** — currently `pi-codes 0.85.1`, tested against pi `0.85.1` (`@earendil-works/pi-coding-agent`; live tier: credential-free RPC surface + model turns and tool conformance when a provider key is present).
 

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.267] - 2026-09-10
+
+### Changed
+
+- Re-pin to Claude CLI **2.1.267**. No stream-json wire drift from
+  2.1.266: the fingerprint check is clean against the committed snapshot,
+  and the live integration suite passes unchanged. Pin-only release.
+
 ## [2.1.266] - 2026-09-09
 
 Re-baseline against Claude CLI **2.1.266**. Models the 2.1.263 → 2.1.266

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.266"
+version = "2.1.267"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.266
+**Tested against:** Claude CLI 2.1.267
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.266**
+//! Current tested version: **2.1.267**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.266";
+const TESTED_VERSION: &str = "2.1.267";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.154.0] - 2026-09-10
+
+### Changed
+
+- Re-pin to Codex CLI **0.154.0**. The schema `codex app-server
+  generate-json-schema` emits from 0.154.0 matches the committed snapshot
+  except `FeedbackUploadResponse.promptHash`, which the snapshot carries
+  from `openai/codex@main` but the 0.154.0 release does not emit yet; the
+  field is already optional, so nothing moves. The live integration suite
+  passes unchanged. Pin-only release.
+
 ## [0.153.5] - 2026-09-10
 
 Resnapshots vs `openai/codex@main` (b348fc2, 2026-09-10).

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.153.5"
+version = "0.154.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.153.4
+**Tested against:** Codex CLI 0.154.0
 
 ## Installation
 
@@ -224,7 +224,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.153.4
+**Tested against:** Codex CLI 0.154.0
 
 The crate version means **tested against**: it names the newest Codex CLI
 the live integration suite has passed against. If you're using a different

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.153.4";
+const TESTED_VERSION: &str = "0.154.0";
 
 /// The Codex CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention.

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-09-10
+
+### Changed
+
+- Re-baseline the tested pin to Muse Code **1.1.1 (1.1.1-R2514.1)**
+  (hosts auto-rolled from 1.0.3): echo fingerprint identical to the
+  snapshot, model catalog unchanged (the four `MuseModel` ids), and the
+  full cargo tier (14 unit + 4 corpus + 8 live echo integration) passes
+  unchanged. Pin-only release.
+
 ## [1.0.3] - 2026-09-06
 
 ### Changed

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "1.0.3"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -8,7 +8,7 @@ journal on stdout: envelope records covering command intake, run lifecycle,
 task lifecycle, and streamed output. This crate types that stream and ships
 an async Tokio client for driving headless runs.
 
-Tested against Muse Code 1.0.3 (`1.0.3-R2198.1`). The crate version may
+Tested against Muse Code 1.1.1 (`1.1.1-R2514.1`). The crate version may
 carry a patch offset above the CLI release for crate-side additions.
 
 ## Captured, not guessed

--- a/muse-codes/src/version.rs
+++ b/muse-codes/src/version.rs
@@ -1,14 +1,14 @@
 //! Version pins this crate is tested against.
 
 /// Muse Code release the live suite last passed against
-/// (`muse --version` reports `Muse Code 1.0.3 (1.0.3-R2198.1)`). The
+/// (`muse --version` reports `Muse Code 1.1.1 (1.1.1-R2514.1)`). The
 /// 0.1.0 and 0.2.1 captures remain committed and still parse — 1.0.1's
 /// wire is a near-superset (its one observed break, `profile_id: null`
 /// on `run.model.configured`, is modeled as `Option`).
-pub const TESTED_MUSE_VERSION: &str = "1.0.3";
+pub const TESTED_MUSE_VERSION: &str = "1.1.1";
 
 /// Full build string of the tested binary.
-pub const TESTED_MUSE_BUILD: &str = "1.0.3-R2198.1";
+pub const TESTED_MUSE_BUILD: &str = "1.1.1-R2514.1";
 
 /// Envelope `schema_version` the models target.
 pub const STREAM_SCHEMA_VERSION: u32 = 1;


### PR DESCRIPTION
Pin-only release train after pulling every agent harness to its latest release and running each crate's live integration suite against it.

| Crate | Old | New | Harness |
|---|---|---|---|
| claude-codes | 2.1.266 | **2.1.267** | Claude CLI 2.1.267 |
| codex-codes | 0.153.5 | **0.154.0** | Codex CLI 0.154.0 |
| muse-codes | 1.0.3 | **1.1.1** | Muse Code 1.1.1 (1.1.1-R2514.1) |

opencode (1.18.30), pi (0.85.1) and google-antigravity (0.1.16) were already at their latest releases and re-verified, so they are unchanged.

## Verification

- **Drift checks**: all five `scripts/check_*_schema_drift.py` exit 0 (claude, codex, muse, opencode, antigravity).
- **Codex 0.154.0**: the schema `codex app-server generate-json-schema` emits from the installed binary matches the committed snapshot except `FeedbackUploadResponse.promptHash`. The snapshot carries that field from `openai/codex@main` (#370), but 0.154.0 does not emit it yet. It is already `Option`, so no type change is needed.
- **Muse 1.1.1**: the echo fingerprint is identical and the model catalog is unchanged (same four `MuseModel` ids).
- **Live suites** (`--features integration-tests`) all pass:
  - claude-codes: 28 live + 3 wrapping-audit tests
  - codex-codes: 14 live tests, `--test-threads=1`
  - muse-codes: 8 live echo tests
  - opencode-codes, pi-codes, antigravity-codes: pass

Merging publishes the three bumped crates via `publish-crates.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
