### PR TITLE
codex-codes 0.154.1: model thread attachments from main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.154.0"
+version = "0.154.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
 - **`claude-codes`** — currently `claude-codes 2.1.267`, tested against Claude CLI `2.1.267`.
-- **`codex-codes`** — currently `codex-codes 0.154.0`, tested against Codex CLI `0.154.0`.
+- **`codex-codes`** — currently `codex-codes 0.154.1`, tested against Codex CLI `0.154.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.30`, tested against opencode `1.18.30`.
 - **`muse-codes`** — currently `muse-codes 1.1.1`, tested against Muse Code `1.1.1` (build `1.1.1-R2514.1`).
 - **`antigravity-codes`** — currently `antigravity-codes 0.1.16`, tested against google-antigravity `0.1.16` (the wheel its bundled harness was generated from).

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.154.1] - 2026-09-11
+
+### Added
+
+- Thread attachments, from `openai/codex@main`: the
+  `thread/attachment/updated` notification is modeled as
+  `Notification::ThreadAttachmentUpdated(ThreadAttachmentUpdatedNotification)`,
+  and the `thread/attachment/add`, `thread/attachment/list`, and
+  `thread/attachment/remove` client requests get `methods` constants plus
+  the `ThreadAttachment`, `ThreadAttachmentAddParams`/`Response`/`Outcome`,
+  `ThreadAttachmentListParams`/`Response`,
+  `ThreadAttachmentRemoveParams`/`Response`, and `ThreadAttachmentOperation`
+  types. The 0.154.0 release does not emit any of these yet; they arrive
+  with the next Codex CLI.
+- `ConfigRequirements.model_provider` and `ConfigRequirements.model_providers`
+  (managed-policy provider pinning). Both optional, so existing payloads
+  round-trip unchanged.
+
+### Changed
+
+- Re-snapshot `tests/schemas/*.json` from `openai/codex@main`
+  (`02a8f038b`).
+- `examples/schema_coverage` now registers eleven notifications that were
+  already modeled in `Notification` but missing from its scorecard
+  (`autoApprovalReview/strictReviewRequired`, `mcpServer/event/stream/notification`,
+  `modelProvider/authRecovery{Started,Completed}`, `project/changed`,
+  `thread/project/updated`, `thread/queue/changed`, `thread/realtime/item/*`,
+  `thread/reverted`), with matching sample payloads. The scorecard reads
+  194/194 modeled and 194/194 with samples.
+
 ## [0.154.0] - 2026-09-10
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.154.0"
+version = "0.154.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -467,6 +467,18 @@ mod samples {
             methods::MODEL_SAFETY_BUFFERING_UPDATED,
             methods::THREAD_ENVIRONMENT_CONNECTED,
             methods::THREAD_ENVIRONMENT_DISCONNECTED,
+            methods::THREAD_ATTACHMENT_UPDATED,
+            methods::STRICT_REVIEW_REQUIRED,
+            methods::MCP_SERVER_EVENT_STREAM,
+            methods::MODEL_PROVIDER_AUTH_RECOVERY_STARTED,
+            methods::MODEL_PROVIDER_AUTH_RECOVERY_COMPLETED,
+            methods::PROJECT_CHANGED,
+            methods::THREAD_PROJECT_UPDATED,
+            methods::THREAD_QUEUE_CHANGED,
+            methods::THREAD_REALTIME_ITEM_COMPLETED,
+            methods::THREAD_REALTIME_ITEM_STARTED,
+            methods::THREAD_REALTIME_ITEM_TRANSCRIPT_DELTA,
+            methods::THREAD_REVERTED,
         ]
         .into_iter()
         .collect()
@@ -489,6 +501,9 @@ mod samples {
             methods::THREAD_UNSUBSCRIBE,
             methods::THREAD_NAME_SET,
             methods::THREAD_METADATA_UPDATE,
+            methods::THREAD_ATTACHMENT_ADD,
+            methods::THREAD_ATTACHMENT_LIST,
+            methods::THREAD_ATTACHMENT_REMOVE,
             methods::THREAD_UNARCHIVE,
             methods::THREAD_COMPACT_START,
             methods::THREAD_SHELLCOMMAND,

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -46,20 +46,20 @@ use crate::protocol::{
     ReasoningSummaryPartAddedNotification, ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification, RemoteControlStatusChangedNotification,
     ServerRequestResolvedNotification, SkillsChangedNotification, StrictReviewRequiredNotification,
-    TerminalInteractionNotification, ThreadArchivedNotification, ThreadClosedNotification,
-    ThreadDeletedNotification, ThreadGoalClearedNotification, ThreadGoalUpdatedNotification,
-    ThreadNameUpdatedNotification, ThreadProjectUpdatedNotification,
-    ThreadQueueChangedNotification, ThreadRealtimeClosedNotification,
-    ThreadRealtimeErrorNotification, ThreadRealtimeItemAddedNotification,
-    ThreadRealtimeItemCompletedNotification, ThreadRealtimeItemStartedNotification,
-    ThreadRealtimeItemTranscriptDeltaNotification, ThreadRealtimeOutputAudioDeltaNotification,
-    ThreadRealtimeSdpNotification, ThreadRealtimeStartedNotification,
-    ThreadRealtimeTranscriptDeltaNotification, ThreadRealtimeTranscriptDoneNotification,
-    ThreadRevertedNotification, ThreadSettingsUpdatedNotification, ThreadStartedNotification,
-    ThreadStatusChangedNotification, ThreadTokenUsageUpdatedNotification,
-    ThreadUnarchivedNotification, TurnCompletedNotification, TurnDiffUpdatedNotification,
-    TurnModerationMetadataNotification, TurnPlanUpdatedNotification, TurnStartedNotification,
-    WarningNotification, WindowsSandboxSetupCompletedNotification,
+    TerminalInteractionNotification, ThreadArchivedNotification,
+    ThreadAttachmentUpdatedNotification, ThreadClosedNotification, ThreadDeletedNotification,
+    ThreadGoalClearedNotification, ThreadGoalUpdatedNotification, ThreadNameUpdatedNotification,
+    ThreadProjectUpdatedNotification, ThreadQueueChangedNotification,
+    ThreadRealtimeClosedNotification, ThreadRealtimeErrorNotification,
+    ThreadRealtimeItemAddedNotification, ThreadRealtimeItemCompletedNotification,
+    ThreadRealtimeItemStartedNotification, ThreadRealtimeItemTranscriptDeltaNotification,
+    ThreadRealtimeOutputAudioDeltaNotification, ThreadRealtimeSdpNotification,
+    ThreadRealtimeStartedNotification, ThreadRealtimeTranscriptDeltaNotification,
+    ThreadRealtimeTranscriptDoneNotification, ThreadRevertedNotification,
+    ThreadSettingsUpdatedNotification, ThreadStartedNotification, ThreadStatusChangedNotification,
+    ThreadTokenUsageUpdatedNotification, ThreadUnarchivedNotification, TurnCompletedNotification,
+    TurnDiffUpdatedNotification, TurnModerationMetadataNotification, TurnPlanUpdatedNotification,
+    TurnStartedNotification, WarningNotification, WindowsSandboxSetupCompletedNotification,
     WindowsWorldWritableWarningNotification,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -137,6 +137,8 @@ pub enum Notification {
     ThreadGoalCleared(ThreadGoalClearedNotification),
     /// `thread/name/updated`
     ThreadNameUpdated(ThreadNameUpdatedNotification),
+    /// `thread/attachment/updated`
+    ThreadAttachmentUpdated(ThreadAttachmentUpdatedNotification),
     /// `skills/changed`
     SkillsChanged(SkillsChangedNotification),
     /// `fs/changed`
@@ -297,6 +299,7 @@ impl Notification {
             Self::ThreadUnarchived(_) => methods::THREAD_UNARCHIVED,
             Self::ThreadGoalCleared(_) => methods::THREAD_GOAL_CLEARED,
             Self::ThreadNameUpdated(_) => methods::THREAD_NAME_UPDATED,
+            Self::ThreadAttachmentUpdated(_) => methods::THREAD_ATTACHMENT_UPDATED,
             Self::SkillsChanged(_) => methods::SKILLS_CHANGED,
             Self::FsChanged(_) => methods::FS_CHANGED,
             Self::ConfigWarning(_) => methods::CONFIG_WARNING,
@@ -535,6 +538,9 @@ impl Notification {
             methods::THREAD_NAME_UPDATED => {
                 serde_json::from_value(params_value).map(Self::ThreadNameUpdated)
             }
+            methods::THREAD_ATTACHMENT_UPDATED => {
+                serde_json::from_value(params_value).map(Self::ThreadAttachmentUpdated)
+            }
             methods::SKILLS_CHANGED => {
                 serde_json::from_value(params_value).map(Self::SkillsChanged)
             }
@@ -716,6 +722,7 @@ impl Notification {
             Self::ThreadUnarchived(v) => pack(methods::THREAD_UNARCHIVED, v),
             Self::ThreadGoalCleared(v) => pack(methods::THREAD_GOAL_CLEARED, v),
             Self::ThreadNameUpdated(v) => pack(methods::THREAD_NAME_UPDATED, v),
+            Self::ThreadAttachmentUpdated(v) => pack(methods::THREAD_ATTACHMENT_UPDATED, v),
             Self::SkillsChanged(v) => pack(methods::SKILLS_CHANGED, v),
             Self::FsChanged(v) => pack(methods::FS_CHANGED, v),
             Self::ConfigWarning(v) => pack(methods::CONFIG_WARNING, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -40,6 +40,9 @@ pub mod methods {
     pub const THREAD_UNSUBSCRIBE: &str = "thread/unsubscribe";
     pub const THREAD_NAME_SET: &str = "thread/name/set";
     pub const THREAD_METADATA_UPDATE: &str = "thread/metadata/update";
+    pub const THREAD_ATTACHMENT_ADD: &str = "thread/attachment/add";
+    pub const THREAD_ATTACHMENT_LIST: &str = "thread/attachment/list";
+    pub const THREAD_ATTACHMENT_REMOVE: &str = "thread/attachment/remove";
     pub const THREAD_UNARCHIVE: &str = "thread/unarchive";
     pub const THREAD_COMPACT_START: &str = "thread/compact/start";
     pub const THREAD_SHELLCOMMAND: &str = "thread/shellCommand";
@@ -169,6 +172,7 @@ pub mod methods {
     pub const THREAD_UNARCHIVED: &str = "thread/unarchived";
     pub const THREAD_GOAL_CLEARED: &str = "thread/goal/cleared";
     pub const THREAD_NAME_UPDATED: &str = "thread/name/updated";
+    pub const THREAD_ATTACHMENT_UPDATED: &str = "thread/attachment/updated";
     pub const SKILLS_CHANGED: &str = "skills/changed";
     pub const FS_CHANGED: &str = "fs/changed";
     pub const CONFIG_WARNING: &str = "configWarning";

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -10,6 +10,10 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         ("account/updated", json!({})),
         ("app/list/updated", json!({"data": []})),
         (
+            "autoApprovalReview/strictReviewRequired",
+            json!({"startedAtMs": 0, "threadId": "x", "turnId": "x"}),
+        ),
+        (
             "command/exec/outputDelta",
             json!({"capReached": false, "deltaBase64": "x", "processId": "x", "stream": null}),
         ),
@@ -102,6 +106,10 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
             json!({"item": {"content": [], "id": "x", "type": "userMessage"}, "startedAtMs": 0, "threadId": "x", "turnId": "x"}),
         ),
         (
+            "mcpServer/event/stream/notification",
+            json!({"notification": {"method": "x", "params": null}, "subscriptionId": "x"}),
+        ),
+        (
             "mcpServer/oauthLogin/completed",
             json!({"name": "x", "success": false}),
         ),
@@ -122,12 +130,24 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
             json!({"threadId": "x", "turnId": "x", "verifications": []}),
         ),
         (
+            "modelProvider/authRecoveryCompleted",
+            json!({"message": "x", "provider": "x", "threadId": "x", "turnId": "x"}),
+        ),
+        (
+            "modelProvider/authRecoveryStarted",
+            json!({"message": "x", "provider": "x", "threadId": "x", "turnId": "x"}),
+        ),
+        (
             "process/exited",
             json!({"exitCode": 0, "processHandle": "x", "stderr": "x", "stderrCapReached": false, "stdout": "x", "stdoutCapReached": false}),
         ),
         (
             "process/outputDelta",
             json!({"capReached": false, "deltaBase64": "x", "processHandle": "x", "stream": null}),
+        ),
+        (
+            "project/changed",
+            json!({"changeType": "created", "projectId": "x"}),
         ),
         (
             "remoteControl/status/changed",
@@ -139,6 +159,10 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         ),
         ("skills/changed", json!({})),
         ("thread/archived", json!({"threadId": "x"})),
+        (
+            "thread/attachment/updated",
+            json!({"attachmentId": "x", "attachmentType": "x", "identityKey": "x", "operation": "created", "threadId": "x"}),
+        ),
         ("thread/closed", json!({"threadId": "x"})),
         ("thread/compacted", json!({"threadId": "x", "turnId": "x"})),
         ("thread/deleted", json!({"threadId": "x"})),
@@ -156,10 +180,27 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
             json!({"goal": {"createdAt": 0, "objective": "x", "status": "active", "threadId": "x", "timeUsedSeconds": 0, "tokensUsed": 0, "updatedAt": 0}, "threadId": "x"}),
         ),
         ("thread/name/updated", json!({"threadId": "x"})),
+        (
+            "thread/project/updated",
+            json!({"projectId": "x", "threadId": "x"}),
+        ),
+        ("thread/queue/changed", json!({"threadId": "x"})),
         ("thread/realtime/closed", json!({"threadId": "x"})),
         (
             "thread/realtime/error",
             json!({"message": "x", "threadId": "x"}),
+        ),
+        (
+            "thread/realtime/item/completed",
+            json!({"item": {"type": "realtimeSessionStarted"}, "threadId": "x"}),
+        ),
+        (
+            "thread/realtime/item/started",
+            json!({"item": {"type": "realtimeSessionStarted"}, "threadId": "x"}),
+        ),
+        (
+            "thread/realtime/item/transcript/delta",
+            json!({"delta": "x", "itemId": "x", "threadId": "x"}),
         ),
         (
             "thread/realtime/itemAdded",
@@ -182,6 +223,7 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
             "thread/realtime/transcript/done",
             json!({"role": "x", "text": "x", "threadId": "x"}),
         ),
+        ("thread/reverted", json!({"threadId": "x"})),
         (
             "thread/settings/updated",
             json!({"threadId": "x", "threadSettings": {"approvalPolicy": "untrusted", "approvalsReviewer": "user", "collaborationMode": {"mode": "plan", "settings": {"model": "x"}}, "cwd": "x", "model": "x", "modelProvider": "x", "sandboxPolicy": {"type": "dangerFullAccess"}}}),
@@ -347,6 +389,15 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
             json!({"event": null, "threadId": "x"}),
         ),
         ("thread/archive", json!({"threadId": "x"})),
+        (
+            "thread/attachment/add",
+            json!({"attachmentType": "x", "identityKey": "x", "payload": null, "threadId": "x"}),
+        ),
+        ("thread/attachment/list", json!({"threadId": "x"})),
+        (
+            "thread/attachment/remove",
+            json!({"attachmentType": "x", "identityKey": "x", "threadId": "x"}),
+        ),
         ("thread/compact/start", json!({"threadId": "x"})),
         ("thread/delete", json!({"threadId": "x"})),
         ("thread/fork", json!({"threadId": "x"})),

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -1589,6 +1589,20 @@ pub struct ConfigRequirements {
         skip_serializing_if = "Option::is_none"
     )]
     pub model_catalog_json: Option<String>,
+    /// Exact provider selection required by managed policy.
+    #[serde(
+        rename = "modelProvider",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_provider: Option<String>,
+    /// Complete required provider definitions, using `config.toml` field names.
+    #[serde(
+        rename = "modelProviders",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_providers: Option<serde_json::Map<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub models: Option<ModelsRequirements>,
     #[serde(
@@ -7158,6 +7172,123 @@ pub struct ThreadArchiveResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadArchivedNotification {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// An independently persisted attachment associated with a thread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachment {
+    #[serde(rename = "attachmentType", default)]
+    pub attachment_type: String,
+    #[serde(rename = "createdAt", default)]
+    pub created_at: i64,
+    #[serde(default)]
+    pub id: String,
+    #[serde(rename = "identityKey", default)]
+    pub identity_key: String,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+/// Result of attempting to associate an attachment with a thread.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ThreadAttachmentAddOutcome {
+    #[serde(rename = "created")]
+    Created,
+    #[serde(rename = "existing")]
+    Existing,
+}
+
+/// Parameters for creating or locating an attachment on its owning thread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentAddParams {
+    #[serde(rename = "attachmentType", default)]
+    pub attachment_type: String,
+    #[serde(rename = "identityKey", default)]
+    pub identity_key: String,
+    #[serde(default)]
+    pub payload: Value,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// The created or existing attachment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentAddResponse {
+    pub attachment: ThreadAttachment,
+    pub outcome: ThreadAttachmentAddOutcome,
+}
+
+/// Parameters for listing attachments from one thread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// One page of attachments associated with the requested thread.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentListResponse {
+    #[serde(default)]
+    pub data: Vec<ThreadAttachment>,
+    #[serde(
+        rename = "nextCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
+/// The persisted attachment change represented by a notification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ThreadAttachmentOperation {
+    #[serde(rename = "created")]
+    Created,
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+
+/// Parameters for deleting an attachment by its stable thread-local identity.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentRemoveParams {
+    #[serde(rename = "attachmentType", default)]
+    pub attachment_type: String,
+    #[serde(rename = "identityKey", default)]
+    pub identity_key: String,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+/// Successful deletion does not return additional attachment data.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentRemoveResponse {
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// Notification published after a thread attachment is created or deleted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadAttachmentUpdatedNotification {
+    #[serde(rename = "attachmentId", default)]
+    pub attachment_id: String,
+    #[serde(rename = "attachmentType", default)]
+    pub attachment_type: String,
+    #[serde(rename = "identityKey", default)]
+    pub identity_key: String,
+    pub operation: ThreadAttachmentOperation,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
 }

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -594,6 +594,7 @@ async fn test_typed_message_audit_strict() {
                     Notification::ThreadUnarchived(_) => "ThreadUnarchived",
                     Notification::ThreadGoalCleared(_) => "ThreadGoalCleared",
                     Notification::ThreadNameUpdated(_) => "ThreadNameUpdated",
+                    Notification::ThreadAttachmentUpdated(_) => "ThreadAttachmentUpdated",
                     Notification::SkillsChanged(_) => "SkillsChanged",
                     Notification::FsChanged(_) => "FsChanged",
                     Notification::ConfigWarning(_) => "ConfigWarning",

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -499,6 +499,78 @@
             },
             "method": {
               "enum": [
+                "thread/attachment/add"
+              ],
+              "title": "Thread/attachment/addRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadAttachmentAddParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/addRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/attachment/list"
+              ],
+              "title": "Thread/attachment/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadAttachmentListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/attachment/remove"
+              ],
+              "title": "Thread/attachment/removeRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadAttachmentRemoveParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/removeRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/section/move"
               ],
               "title": "Thread/section/moveRequestMethod",
@@ -4676,6 +4748,26 @@
             "params"
           ],
           "title": "Thread/name/updatedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/attachment/updated"
+              ],
+              "title": "Thread/attachment/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadAttachmentUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/updatedNotification",
           "type": "object"
         },
         {
@@ -9902,6 +9994,21 @@
           "modelCatalogJson": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "modelProvider": {
+            "description": "Exact provider selection required by managed policy.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modelProviders": {
+            "additionalProperties": true,
+            "description": "Complete required provider definitions, using config.toml field names.",
+            "type": [
+              "object",
               "null"
             ]
           },
@@ -20551,6 +20658,200 @@
           "threadId"
         ],
         "title": "ThreadArchivedNotification",
+        "type": "object"
+      },
+      "ThreadAttachment": {
+        "description": "An independently persisted attachment associated with a thread.",
+        "properties": {
+          "attachmentType": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "identityKey": {
+            "type": "string"
+          },
+          "payload": true
+        },
+        "required": [
+          "attachmentType",
+          "createdAt",
+          "id",
+          "identityKey",
+          "payload"
+        ],
+        "type": "object"
+      },
+      "ThreadAttachmentAddOutcome": {
+        "description": "Result of attempting to associate an attachment with a thread.",
+        "enum": [
+          "created",
+          "existing"
+        ],
+        "type": "string"
+      },
+      "ThreadAttachmentAddParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Parameters for creating or locating an attachment on its owning thread.",
+        "properties": {
+          "attachmentType": {
+            "type": "string"
+          },
+          "identityKey": {
+            "type": "string"
+          },
+          "payload": true,
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachmentType",
+          "identityKey",
+          "payload",
+          "threadId"
+        ],
+        "title": "ThreadAttachmentAddParams",
+        "type": "object"
+      },
+      "ThreadAttachmentAddResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "The created or existing attachment.",
+        "properties": {
+          "attachment": {
+            "$ref": "#/definitions/v2/ThreadAttachment"
+          },
+          "outcome": {
+            "$ref": "#/definitions/v2/ThreadAttachmentAddOutcome"
+          }
+        },
+        "required": [
+          "attachment",
+          "outcome"
+        ],
+        "title": "ThreadAttachmentAddResponse",
+        "type": "object"
+      },
+      "ThreadAttachmentListParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Parameters for listing attachments from one thread.",
+        "properties": {
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadAttachmentListParams",
+        "type": "object"
+      },
+      "ThreadAttachmentListResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "One page of attachments associated with the requested thread.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/ThreadAttachment"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ThreadAttachmentListResponse",
+        "type": "object"
+      },
+      "ThreadAttachmentOperation": {
+        "description": "The persisted attachment change represented by a notification.",
+        "enum": [
+          "created",
+          "deleted"
+        ],
+        "type": "string"
+      },
+      "ThreadAttachmentRemoveParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Parameters for deleting an attachment by its stable thread-local identity.",
+        "properties": {
+          "attachmentType": {
+            "type": "string"
+          },
+          "identityKey": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachmentType",
+          "identityKey",
+          "threadId"
+        ],
+        "title": "ThreadAttachmentRemoveParams",
+        "type": "object"
+      },
+      "ThreadAttachmentRemoveResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Successful deletion does not return additional attachment data.",
+        "title": "ThreadAttachmentRemoveResponse",
+        "type": "object"
+      },
+      "ThreadAttachmentUpdatedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Notification published after a thread attachment is created or deleted.",
+        "properties": {
+          "attachmentId": {
+            "type": "string"
+          },
+          "attachmentType": {
+            "type": "string"
+          },
+          "identityKey": {
+            "type": "string"
+          },
+          "operation": {
+            "$ref": "#/definitions/v2/ThreadAttachmentOperation"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "attachmentId",
+          "attachmentType",
+          "identityKey",
+          "operation",
+          "threadId"
+        ],
+        "title": "ThreadAttachmentUpdatedNotification",
         "type": "object"
       },
       "ThreadClosedNotification": {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -2029,6 +2029,78 @@
             },
             "method": {
               "enum": [
+                "thread/attachment/add"
+              ],
+              "title": "Thread/attachment/addRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadAttachmentAddParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/addRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/attachment/list"
+              ],
+              "title": "Thread/attachment/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadAttachmentListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/attachment/remove"
+              ],
+              "title": "Thread/attachment/removeRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadAttachmentRemoveParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/removeRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/section/move"
               ],
               "title": "Thread/section/moveRequestMethod",
@@ -5802,6 +5874,21 @@
         "modelCatalogJson": {
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "modelProvider": {
+          "description": "Exact provider selection required by managed policy.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modelProviders": {
+          "additionalProperties": true,
+          "description": "Complete required provider definitions, using config.toml field names.",
+          "type": [
+            "object",
             "null"
           ]
         },
@@ -15823,6 +15910,26 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/attachment/updated"
+              ],
+              "title": "Thread/attachment/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadAttachmentUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/attachment/updatedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/goal/updated"
               ],
               "title": "Thread/goal/updatedNotificationMethod",
@@ -18265,6 +18372,200 @@
         "threadId"
       ],
       "title": "ThreadArchivedNotification",
+      "type": "object"
+    },
+    "ThreadAttachment": {
+      "description": "An independently persisted attachment associated with a thread.",
+      "properties": {
+        "attachmentType": {
+          "type": "string"
+        },
+        "createdAt": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "identityKey": {
+          "type": "string"
+        },
+        "payload": true
+      },
+      "required": [
+        "attachmentType",
+        "createdAt",
+        "id",
+        "identityKey",
+        "payload"
+      ],
+      "type": "object"
+    },
+    "ThreadAttachmentAddOutcome": {
+      "description": "Result of attempting to associate an attachment with a thread.",
+      "enum": [
+        "created",
+        "existing"
+      ],
+      "type": "string"
+    },
+    "ThreadAttachmentAddParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Parameters for creating or locating an attachment on its owning thread.",
+      "properties": {
+        "attachmentType": {
+          "type": "string"
+        },
+        "identityKey": {
+          "type": "string"
+        },
+        "payload": true,
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "attachmentType",
+        "identityKey",
+        "payload",
+        "threadId"
+      ],
+      "title": "ThreadAttachmentAddParams",
+      "type": "object"
+    },
+    "ThreadAttachmentAddResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "The created or existing attachment.",
+      "properties": {
+        "attachment": {
+          "$ref": "#/definitions/ThreadAttachment"
+        },
+        "outcome": {
+          "$ref": "#/definitions/ThreadAttachmentAddOutcome"
+        }
+      },
+      "required": [
+        "attachment",
+        "outcome"
+      ],
+      "title": "ThreadAttachmentAddResponse",
+      "type": "object"
+    },
+    "ThreadAttachmentListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Parameters for listing attachments from one thread.",
+      "properties": {
+        "cursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadAttachmentListParams",
+      "type": "object"
+    },
+    "ThreadAttachmentListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "One page of attachments associated with the requested thread.",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/ThreadAttachment"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "title": "ThreadAttachmentListResponse",
+      "type": "object"
+    },
+    "ThreadAttachmentOperation": {
+      "description": "The persisted attachment change represented by a notification.",
+      "enum": [
+        "created",
+        "deleted"
+      ],
+      "type": "string"
+    },
+    "ThreadAttachmentRemoveParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Parameters for deleting an attachment by its stable thread-local identity.",
+      "properties": {
+        "attachmentType": {
+          "type": "string"
+        },
+        "identityKey": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "attachmentType",
+        "identityKey",
+        "threadId"
+      ],
+      "title": "ThreadAttachmentRemoveParams",
+      "type": "object"
+    },
+    "ThreadAttachmentRemoveResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Successful deletion does not return additional attachment data.",
+      "title": "ThreadAttachmentRemoveResponse",
+      "type": "object"
+    },
+    "ThreadAttachmentUpdatedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Notification published after a thread attachment is created or deleted.",
+      "properties": {
+        "attachmentId": {
+          "type": "string"
+        },
+        "attachmentType": {
+          "type": "string"
+        },
+        "identityKey": {
+          "type": "string"
+        },
+        "operation": {
+          "$ref": "#/definitions/ThreadAttachmentOperation"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "attachmentId",
+        "attachmentType",
+        "identityKey",
+        "operation",
+        "threadId"
+      ],
+      "title": "ThreadAttachmentUpdatedNotification",
       "type": "object"
     },
     "ThreadClosedNotification": {


### PR DESCRIPTION
## Summary

Nightly-style drift sweep: `scripts/check_codex_schema_drift.py` reported the committed snapshot behind `openai/codex@main`. The installed 0.154.0 release does not emit any of this yet (its own `generate-json-schema` output matches the old snapshot except the already-optional `FeedbackUploadResponse.promptHash`), so this is main-only drift modeled ahead of the next CLI.

- Re-snapshot both `tests/schemas/*.json` from `openai/codex@main` (`02a8f038b`). Drift check is JSON-identical afterwards.
- **Thread attachments**: `thread/attachment/updated` becomes `Notification::ThreadAttachmentUpdated`; `thread/attachment/{add,list,remove}` get `methods` constants. Ten new types (`ThreadAttachment`, `ThreadAttachmentAddParams/Response/Outcome`, `ThreadAttachmentListParams/Response`, `ThreadAttachmentRemoveParams/Response`, `ThreadAttachmentOperation`, `ThreadAttachmentUpdatedNotification`) hand-mirrored from `codex-rs/app-server-protocol/src/protocol/v2/thread_attachment.rs`.
- `ConfigRequirements.model_provider` / `.model_providers` (managed-policy provider pinning), both optional.
- `examples/schema_coverage`: eleven notifications were already modeled but never registered in the scorecard. Registered them with sample payloads; scorecard now reads 194/194 modeled and 194/194 with samples.
- Patch bump to 0.154.1 (tested pin stays 0.154.0).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p codex-codes` green
- `cargo test -p codex-codes --features integration-tests -- --test-threads=1` green against codex 0.154.0 (14 live tests)
- `cargo run -p codex-codes --example schema_coverage` 100%/100%
- `python3 scripts/check_codex_schema_drift.py` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
