### PR TITLE
claude-codes 2.1.268: model 2.1.267 to 2.1.268 stream-json drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.267"
+version = "2.1.268"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.267`, tested against Claude CLI `2.1.267`.
+- **`claude-codes`** — currently `claude-codes 2.1.268`, tested against Claude CLI `2.1.268`.
 - **`codex-codes`** — currently `codex-codes 0.154.0`, tested against Codex CLI `0.154.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.30`, tested against opencode `1.18.30`.
 - **`muse-codes`** — currently `muse-codes 1.1.1`, tested against Muse Code `1.1.1` (build `1.1.1-R2514.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.268] - 2026-09-11
+
+Re-baseline against Claude CLI **2.1.268**. Models the 2.1.267 → 2.1.268
+stream-json drift, all additive (no removals or required/optional flips).
+
+### Added
+
+- `resume_reason` on `AssistantMessage`, `StreamEventMessage`, and
+  `ResultMessage` — why the turn is the automatic re-run of a turn a worker
+  restart interrupted (`CLAUDE_CODE_RESUME_INTERRUPTED_TURN`): the host's
+  `CLAUDE_CODE_RESUME_REASON` when it set one (`host_draining`,
+  `checkpoint_restore`, `container_recreated`, ...), else `interrupted_turn`.
+  Stamped on the same reply frames as `user_message_uuid`, and on the
+  re-run's result whether success or error.
+- `ResultMessage.result_index` — delivery sequence of the result within the
+  run, numbered by the hosting process in write order starting at 0. A
+  result whose write fails still consumes its number, so a gap means a
+  result was lost.
+- `ResultMessage.local_command` — the local slash command that produced a
+  success result when the query loop was bypassed.
+
+### Changed
+
+- Re-pin to Claude CLI **2.1.268**; snapshot refreshed. The live
+  integration suite passes unchanged.
+
 ## [2.1.267] - 2026-09-10
 
 ### Changed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.267"
+version = "2.1.268"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.267
+**Tested against:** Claude CLI 2.1.268
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -121,6 +121,14 @@ pub struct StreamEventMessage {
     /// from CLIs before 2.1.259 (fall back to `user_message_uuid`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub user_message_uuids: Vec<String>,
+    /// Why this frame's turn is the automatic re-run of a turn a worker
+    /// restart interrupted: the host's `CLAUDE_CODE_RESUME_REASON` when it set
+    /// one, else `interrupted_turn`. Stamped on the same reply frames as
+    /// `user_message_uuid`, so a consumer can tell the re-run's first reply
+    /// from the interrupted attempt's. Absent on every other turn, on
+    /// `thinking_tokens` frames, and from CLIs before 2.1.268.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -2737,6 +2737,15 @@ pub struct AssistantMessage {
     /// also stamps it on deliveries it replays (CLI 2.1.266+).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub historical: Option<bool>,
+    /// Why this frame's turn is the automatic re-run of a turn a worker
+    /// restart interrupted: the host's `CLAUDE_CODE_RESUME_REASON` when it set
+    /// one (`host_draining`, `checkpoint_restore`, `container_recreated`,
+    /// ...), else `interrupted_turn`. Stamped on the same reply frames as
+    /// `user_message_uuid`, which on such a re-run names the interrupted
+    /// turn's own last user prompt. Absent on every other turn and from CLIs
+    /// before 2.1.268.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_reason: Option<String>,
     /// The originating `system/local_command` row's wire-form content,
     /// carried on the loop-synthesized local-command twin so a bridge/SDK
     /// history replay rebuilds the internal system row instead of dropping

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -72,6 +72,22 @@ pub struct ResultMessage {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub user_message_uuids: Vec<String>,
 
+    /// Why this turn was the automatic re-run of a turn a worker restart
+    /// interrupted (`CLAUDE_CODE_RESUME_INTERRUPTED_TURN`): the host's
+    /// `CLAUDE_CODE_RESUME_REASON` when it set one (`host_draining`,
+    /// `checkpoint_restore`, `container_recreated`, ...), else
+    /// `interrupted_turn`. Present on a headless re-run's result, success or
+    /// error; absent on every other turn, on the Remote Control bridge's
+    /// per-turn synthetic results, and from CLIs before 2.1.268.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_reason: Option<String>,
+
+    /// The local slash command that produced this result when the query loop
+    /// was bypassed (success results only). Absent when the turn went to the
+    /// model and from CLIs before 2.1.268.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_command: Option<String>,
+
     /// User-initiated sends still waiting in the command queue when this
     /// result was produced. Greater than 0 means at least one more user turn
     /// follows without further input, barring cancellation. Absent on fatal
@@ -117,6 +133,16 @@ pub struct ResultMessage {
     /// Why the session ended (e.g., "completed")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_reason: Option<String>,
+
+    /// Delivery sequence of this result within the run: how many results the
+    /// run numbered before this one, starting at 0, in the order the process
+    /// writes them. A result whose write fails still consumes its number, so
+    /// a gap means a result was lost. Distinct from `num_turns`. Numbered by
+    /// the process hosting the run (`claude -p`); a local client relaying a
+    /// cloud session passes the cloud numbering through and its own locally
+    /// built error results carry none. Absent from CLIs before 2.1.268.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_index: Option<u64>,
 
     /// Fast mode toggle state (e.g., "off")
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.267**
+//! Current tested version: **2.1.268**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.267";
+const TESTED_VERSION: &str = "2.1.268";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention

--- a/claude-codes/tests/schema_2_1_268_tests.rs
+++ b/claude-codes/tests/schema_2_1_268_tests.rs
@@ -1,0 +1,170 @@
+//! Coverage for the CLI 2.1.268 stream-json additive drift.
+//!
+//! 2.1.267 → 2.1.268 added top-level fields to the `assistant`,
+//! `stream_event`, and `result` wire types, all additive (no removals):
+//! `resume_reason` on all three, plus `result_index` and `local_command` on
+//! `result`.
+//!
+//! Each frame below carries the new fields and is asserted **fully wrapped** —
+//! the typed model captures every wire field with nothing left in an untyped
+//! escape hatch.
+
+use claude_codes::{assert_fully_wrapped, ClaudeOutput};
+use serde_json::json;
+
+/// An `assistant` frame stamped with `resume_reason` on a restart re-run
+/// round-trips without loss, and older frames leave the key absent.
+#[test]
+fn assistant_carries_resume_reason() {
+    let frame = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "done"}],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1",
+        "uuid": "u1",
+        "parent_tool_use_id": null,
+        "user_message_uuid": "um1",
+        "resume_reason": "host_draining"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.resume_reason.as_deref(), Some("host_draining"));
+    assert_eq!(msg.user_message_uuid.as_deref(), Some("um1"));
+
+    let old = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [],
+            "stop_reason": null,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        },
+        "session_id": "s1"
+    });
+    let ClaudeOutput::Assistant(msg) = serde_json::from_value(old).unwrap() else {
+        panic!("expected assistant");
+    };
+    assert_eq!(msg.resume_reason, None);
+    let reserialized = serde_json::to_string(&msg).unwrap();
+    assert!(!reserialized.contains("resume_reason"));
+}
+
+/// A `stream_event` frame stamped with `resume_reason` round-trips fully
+/// wrapped.
+#[test]
+fn stream_event_carries_resume_reason() {
+    let frame = json!({
+        "type": "stream_event",
+        "event": {"type": "message_start"},
+        "parent_tool_use_id": null,
+        "uuid": "u1",
+        "session_id": "s1",
+        "user_message_uuid": "um1",
+        "user_message_uuids": ["um1"],
+        "resume_reason": "interrupted_turn"
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::StreamEvent(ev) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected stream_event");
+    };
+    assert_eq!(ev.resume_reason.as_deref(), Some("interrupted_turn"));
+}
+
+/// A success `result` carrying the 2.1.268 `resume_reason`, `local_command`,
+/// and `result_index` fields round-trips fully wrapped.
+#[test]
+fn result_success_carries_resume_reason_local_command_and_index() {
+    let frame = json!({
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "duration_ms": 5,
+        "duration_api_ms": 0,
+        "num_turns": 1,
+        "result": "ok",
+        "session_id": "s1",
+        "total_cost_usd": 0.0,
+        "resume_reason": "checkpoint_restore",
+        "local_command": "/status",
+        "result_index": 3
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Result(res) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected result");
+    };
+    assert_eq!(res.resume_reason.as_deref(), Some("checkpoint_restore"));
+    assert_eq!(res.local_command.as_deref(), Some("/status"));
+    assert_eq!(res.result_index, Some(3));
+}
+
+/// An error `result` carries `resume_reason` and `result_index` too (the CLI
+/// stamps the reason on the re-run's result whether success or error), and a
+/// result without them leaves the keys absent on reserialization.
+#[test]
+fn result_error_carries_resume_reason_and_index() {
+    let frame = json!({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": true,
+        "duration_ms": 5,
+        "duration_api_ms": 0,
+        "num_turns": 0,
+        "session_id": "s1",
+        "total_cost_usd": 0.0,
+        "resume_reason": "container_recreated",
+        "result_index": 0
+    });
+    assert_fully_wrapped(&frame);
+
+    let ClaudeOutput::Result(res) = serde_json::from_value(frame).unwrap() else {
+        panic!("expected result");
+    };
+    assert_eq!(res.resume_reason.as_deref(), Some("container_recreated"));
+    assert_eq!(res.result_index, Some(0));
+    assert_eq!(res.local_command, None);
+
+    let old = json!({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": true,
+        "duration_ms": 5,
+        "duration_api_ms": 0,
+        "num_turns": 0,
+        "session_id": "s1",
+        "total_cost_usd": 0.0
+    });
+    let ClaudeOutput::Result(res) = serde_json::from_value(old).unwrap() else {
+        panic!("expected result");
+    };
+    assert_eq!(res.resume_reason, None);
+    assert_eq!(res.result_index, None);
+    let reserialized = serde_json::to_string(&res).unwrap();
+    assert!(!reserialized.contains("resume_reason"));
+    assert!(!reserialized.contains("result_index"));
+    assert!(!reserialized.contains("local_command"));
+}

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -5,7 +5,7 @@
 # see the header of check_claude_schema_drift.py for the comparison contract.
 # union_members: 45
 
-assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, historical, is_api_error_message, is_meta, is_virtual, local_command_source, message, narration_block_indexes, parent_tool_use_id, request_id, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_ingest_context, wire_tool_inputs
+assistant: aborted, advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, batch_tool_uses, context_usage, error, error_details, historical, is_api_error_message, is_meta, is_virtual, local_command_source, message, narration_block_indexes, parent_tool_use_id, request_id, resume_reason, resumed_from_incomplete_thinking, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, user_message_uuid, user_message_uuids, uuid, wire_ingest_context, wire_tool_inputs
 auth_status: error, isAuthenticating, output, session_id, type, uuid
 command_lifecycle: command_uuid, session_id, state, type, uuid
 content: content, type
@@ -17,10 +17,10 @@ message: container, content, context_management, id, model, role, stop_details, 
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
 redacted_thinking: data, type
-result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, runner_exit, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, first_content_frame_ms, first_stream_post_ack_ms, first_stream_post_ms, first_stream_post_wall_ms, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, queued_turn_count, result_index, resume_reason, runner_exit, session_id, stop_reason, subagent_stats, subtype, terminal_reason, total_cost_usd, type, usage, user_message_uuid, user_message_uuids, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, first_content_frame_ms, first_stream_post_ack_ms, first_stream_post_ms, first_stream_post_wall_ms, is_error, local_command, modelUsage, num_turns, origin, permission_denials, queued_turn_count, request_sent_wall_ms, result, result_index, resume_reason, session_id, stop_reason, structured_output, subagent_stats, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, user_message_uuids, uuid, warm_spare_claimed
 search_result: cache_control, citations, content, source, title, type
-stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, user_message_uuid, user_message_uuids, uuid
+stream_event: event, parent_tool_use_id, resume_reason, session_id, ttft_ms, type, user_message_uuid, user_message_uuids, uuid
 system/api_retry: attempt, error, error_status, max_retries, no_response, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
 system/cloud_session_delta: changed, cloud_session, seq, session_id, subtype, type, uuid


### PR DESCRIPTION
## Summary

Claude Code **2.1.268** shipped after yesterday's pin, and `scripts/check_claude_schema_drift.py` against it reports additive top-level field drift on `assistant`, `stream_event`, `result`, and `result/success`. A full extraction diff of 2.1.267 vs 2.1.268 (minified names normalized) confirms these three fields are the only wire change. No removals, no required/optional flips.

### New fields

- `resume_reason: Option<String>` on `AssistantMessage`, `StreamEventMessage`, and `ResultMessage`. Why the turn is the automatic re-run of a turn a worker restart interrupted (`CLAUDE_CODE_RESUME_INTERRUPTED_TURN`): the host's `CLAUDE_CODE_RESUME_REASON` when set (`host_draining`, `checkpoint_restore`, `container_recreated`, ...), else `interrupted_turn`. Stamped on the same reply frames as `user_message_uuid`, and on the re-run's result whether success or error.
- `ResultMessage.result_index: Option<u64>`. Delivery sequence of the result within the run, numbered by the hosting process in write order from 0. A failed write still consumes its number, so a gap means a lost result.
- `ResultMessage.local_command: Option<String>`. The local slash command that produced a success result when the query loop was bypassed.

### Pins

Crate version, `TESTED_VERSION`, `lib.rs` doc, and both README `Tested against` lines move to 2.1.268. Snapshot refreshed with `--update`.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p claude-codes` green; new `tests/schema_2_1_268_tests.rs` asserts each new frame is fully wrapped (4 tests)
- `cargo test -p claude-codes --features integration-tests` green against claude 2.1.268 (28 live tests)
- `python3 scripts/check_claude_schema_drift.py` exit 0 against the refreshed snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
