### PR TITLE
claude-codes 2.1.269: re-pin, no stream-json drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.268"
+version = "2.1.269"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ catches up, the next tested release jumps to or past the CLI's number.
 metadata can't distinguish published versions — so explicit offset notes are
 the least-bad scheme.)
 
-- **`claude-codes`** — currently `claude-codes 2.1.268`, tested against Claude CLI `2.1.268`.
+- **`claude-codes`** — currently `claude-codes 2.1.269`, tested against Claude CLI `2.1.269`.
 - **`codex-codes`** — currently `codex-codes 0.154.1`, tested against Codex CLI `0.154.0`.
 - **`opencode-codes`** — currently `opencode-codes 1.18.30`, tested against opencode `1.18.30`.
 - **`muse-codes`** — currently `muse-codes 1.1.1`, tested against Muse Code `1.1.1` (build `1.1.1-R2514.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.269] - 2026-09-12
+
+### Changed
+
+- Re-pin to Claude CLI **2.1.269**. No stream-json wire drift from
+  2.1.268: the fingerprint check is clean against the committed snapshot,
+  and a field-level diff of the extracted zod schemas shows only minified
+  alias churn and doc-string edits. The one substantive doc change is that
+  `user_message_uuid` is now stamped on both the turn's first non-ping
+  stream event and its first complete assistant message, independently, so
+  the same uuid may appear on both frames. The live integration suite
+  passes unchanged. Pin-only release.
+
 ## [2.1.268] - 2026-09-11
 
 Re-baseline against Claude CLI **2.1.268**. Models the 2.1.267 → 2.1.268

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.268"
+version = "2.1.269"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.268
+**Tested against:** Claude CLI 2.1.269
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -110,9 +110,11 @@ pub struct StreamEventMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ttft_ms: Option<u64>,
     /// Client uuid of the user message that triggered this turn, stamped on
-    /// the turn's first non-ping stream event only so a consumer can bind the
-    /// reply stream to the send it answers. Absent on later stream events, on
-    /// synthetic/scheduled turns, and from CLIs before 2.1.259.
+    /// the turn's first non-ping stream event so a consumer can bind the
+    /// reply stream to the send it answers. Since CLI 2.1.269 the turn's
+    /// first complete assistant message is stamped too, independently, so
+    /// the same uuid may appear on both frames. Absent on later stream
+    /// events, on synthetic/scheduled turns, and from CLIs before 2.1.259.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_message_uuid: Option<String>,
     /// Client uuids of every user message whose prompt this turn has consumed

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -2673,10 +2673,13 @@ pub struct AssistantMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
     /// Client uuid of the user message that triggered this turn, stamped on
-    /// the turn's first reply frame only so a consumer can bind the reply to
-    /// the send it answers without waiting for the result. Absent on every
-    /// later frame of the turn, on subagent frames, on synthetic/scheduled
-    /// (meta) turns, and from CLIs before 2.1.259.
+    /// the turn's first top-level assistant message so a consumer can bind
+    /// the reply to the send it answers without waiting for the result. With
+    /// `--include-partial-messages` the first non-ping stream event is
+    /// stamped too, independently (CLI 2.1.269+), so the same uuid may
+    /// appear on both frames. Absent on every later assistant message of the
+    /// turn, on subagent frames, on synthetic/scheduled (meta) turns, and
+    /// from CLIs before 2.1.259.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_message_uuid: Option<String>,
     /// Client uuids of every user message whose prompt this turn has consumed

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.268**
+//! Current tested version: **2.1.269**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.268";
+const TESTED_VERSION: &str = "2.1.269";
 
 /// The Claude CLI release this crate's live integration suite last passed
 /// against — the machine-readable form of the crate's version convention


### PR DESCRIPTION
## Summary

- Re-pin `claude-codes` to Claude CLI **2.1.269** (Cargo.toml, `TESTED_VERSION`, lib doc line, both README lines, CHANGELOG).
- No wire drift: `check_claude_schema_drift.py` is clean against the committed snapshot (`--update` is a no-op), and a per-block token diff of the zod schemas extracted from 2.1.268 vs 2.1.269 shows only minified alias churn and doc-string edits.
- The one substantive doc change upstream: `user_message_uuid` is now stamped on both the turn's first non-ping stream event and its first complete assistant message, independently. The rustdoc on `StreamEventMessage` and `AssistantMessage` is updated to match.

## Verification

- `cargo test -p claude-codes --features integration-tests` against the installed 2.1.269: all pass.
- `cargo clippy -p claude-codes --all-targets --all-features -- -D warnings` clean, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)